### PR TITLE
Mono 5.16.0.179 support

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,8 +10,8 @@ BBFILE_PATTERN_mono := "^${LAYERDIR}/"
 BBFILE_PRIORITY_mono = "1"
 
 # Default tested with qemux86/qemuarm
-PREFERRED_VERSION_mono ?= "5.14.0.177"
-PREFERRED_VERSION_mono-native ?= "5.14.0.177"
+PREFERRED_VERSION_mono ?= "5.16.0.179"
+PREFERRED_VERSION_mono-native ?= "5.16.0.179"
 
 PREFERRED_VERSION_nuget ?= "4.7.0"
 PREFERRED_VERSION_nuget-native ?= "4.7.0"

--- a/recipes-mono/mono/mono-5.16.0.179.inc
+++ b/recipes-mono/mono/mono-5.16.0.179.inc
@@ -1,0 +1,6 @@
+SRC_URI[md5sum] = "76b4f7187287ff49832d38446fe692f9"
+SRC_URI[sha256sum] = "93839af2ef0b8796935d8c1efd4cc693bc294bb2beb657b9edb6b4764f01e12b"
+
+SRC_URI += " file://shm_open-test-crosscompile.diff "
+
+S = "${WORKDIR}/mono-${PV}"

--- a/recipes-mono/mono/mono-5.16.0.179/dllmap-config.in.diff
+++ b/recipes-mono/mono/mono-5.16.0.179/dllmap-config.in.diff
@@ -1,0 +1,31 @@
+diff -ur mono-5.16.0.179.orig/data/config.in mono-5.16.0.179/data/config.in
+--- mono-5.16.0.179.orig/data/config.in	2018-10-05 03:46:00.000000000 -0400
++++ mono-5.16.0.179/data/config.in	2018-11-08 03:49:21.565183148 -0500
+@@ -10,14 +10,14 @@
+ 	<dllmap dll="i:odbc32.dll" target="libiodbc.dylib" os="osx"/>
+ 	<dllmap dll="oci" target="libclntsh@libsuffix@" os="!windows"/>
+ 	<dllmap dll="db2cli" target="libdb2_36@libsuffix@" os="!windows"/>
+-	<dllmap dll="MonoPosixHelper" target="$mono_libdir/libMonoPosixHelper@libsuffix@" os="!windows" />
++	<dllmap dll="MonoPosixHelper" target="libMonoPosixHelper.so" os="!windows" />
+ 	<dllmap dll="System.Native" target="$mono_libdir/libmono-system-native@libsuffix@" os="!windows" />
+ 	<dllmap dll="libmono-btls-shared" target="$mono_libdir/libmono-btls-shared@libsuffix@" os="!windows" />
+ 	<dllmap dll="i:msvcrt" target="@LIBC@" os="!windows"/>
+ 	<dllmap dll="i:msvcrt.dll" target="@LIBC@" os="!windows"/>
+ 	<dllmap dll="sqlite" target="@SQLITE@" os="!windows"/>
+ 	<dllmap dll="sqlite3" target="@SQLITE3@" os="!windows"/>
+-	<dllmap dll="libX11" target="@X11@" os="!windows" />
++	<dllmap dll="libX11" target="libX11.so.6" os="!windows" />
+ 	<dllmap dll="libgdk-x11-2.0" target="@GDKX11@" os="!windows"/>
+ 	<dllmap dll="libgdk_pixbuf-2.0" target="libgdk_pixbuf-2.0.so.0" os="!windows"/>
+ 	<dllmap dll="libgtk-x11-2.0" target="@GTKX11@" os="!windows"/>
+@@ -37,8 +37,8 @@
+ 		<dllentry dll="__Internal" name="MoveMemory" target="mono_win32_compat_MoveMemory"/>
+ 		<dllentry dll="__Internal" name="ZeroMemory" target="mono_win32_compat_ZeroMemory"/>
+ 	</dllmap>
+-	<dllmap dll="gdiplus" target="@libgdiplus_install_loc@" os="!windows"/>
+-	<dllmap dll="gdiplus.dll" target="@libgdiplus_install_loc@"  os="!windows"/>
++	<dllmap dll="gdiplus" target="libgdiplus.so.0" os="!windows"/>
++	<dllmap dll="gdiplus.dll" target="libgdiplus.so.0"  os="!windows"/>
+ 	<dllmap dll="gdi32" target="@libgdiplus_install_loc@" os="!windows"/>
+ 	<dllmap dll="gdi32.dll" target="@libgdiplus_install_loc@" os="!windows"/>
+ </configuration>

--- a/recipes-mono/mono/mono-5.16.0.179/shm_open-test-crosscompile.diff
+++ b/recipes-mono/mono/mono-5.16.0.179/shm_open-test-crosscompile.diff
@@ -1,0 +1,12 @@
+--- mono-5.16.0.179/configure.ac~	2018-10-05 03:51:07.000000000 -0400
++++ mono-5.16.0.179/configure.ac	2018-11-08 05:21:11.848878136 -0500
+@@ -3199,6 +3199,9 @@
+ 			AC_DEFINE(HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP, 1, [shm_open that works well enough with mmap])
+ 		], [
+ 			AC_MSG_RESULT(no)
++		], [
++			AC_MSG_RESULT(yes)
++			AC_DEFINE(HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP, 1, [shm_open that works well enough with mmap])
+ 		])
+ 	fi
+ 

--- a/recipes-mono/mono/mono-native_5.16.0.179.bb
+++ b/recipes-mono/mono/mono-native_5.16.0.179.bb
@@ -1,0 +1,6 @@
+require mono-5.xx.inc
+require mono-mit-bsd.inc
+require mono-native-5.xx-base.inc
+require mono-${PV}.inc
+
+DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono_5.16.0.179.bb
+++ b/recipes-mono/mono/mono_5.16.0.179.bb
@@ -1,0 +1,7 @@
+require mono-5.xx.inc
+require mono-mit-bsd.inc
+require ${PN}-base.inc
+require mono-${PV}.inc
+
+PACKAGES += "${PN}-profiler "
+FILES_${PN}-profiler += " ${datadir}/mono-2.0/mono/profiler/*"


### PR DESCRIPTION
Just a test.

It certainly fails to build as is on Yocto 2.5 when building for genericx86 (32-bit) on x86_64.

The CMake build system has changes in this Mono version so some parts are built with the native compiler.