### PR TITLE
classes/mono.bbclass: Don't override HOME

### DIFF
--- a/classes/mono.bbclass
+++ b/classes/mono.bbclass
@@ -33,10 +33,11 @@ FILES_${PN}-doc += "\
 
 export MONO_CFG_DIR="${STAGING_ETCDIR_NATIVE}"
 
-# NuGet uses $HOME but we should not use anything
-# outside the build root of the packages.
-export HOME="${WORKDIR}/mono-home-dir"
+# NuGet uses $HOME/.nuget/packages to store packages by default
+# but we should not use anything outside the build root of packages.
+export NUGET_PACKAGES="${WORKDIR}/mono-nuget-packages"
+export NUGET_HTTP_CACHE_PATH="${WORKDIR}/mono-nuget-http-cache"
 
 do_configure_prepend() {
-	mkdir -p ${HOME}
+	mkdir -p ${NUGET_PACKAGES} ${NUGET_HTTP_CACHE_PATH}
 }


### PR DESCRIPTION
Set NUGET_PACKAGES and NUGET_HTTP_CACHE_PATH instead of HOME.
Overriding the HOME environment variable clashes with RPM signing.

Signed-off-by: Böszörményi Zoltán <zboszor@pr.hu>