### PR TITLE
Zeus fixes

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -19,4 +19,4 @@ PREFERRED_VERSION_nuget-native ?= "4.7.0"
 PREFERRED_VERSION_msbuild ?= "15.4"
 PREFERRED_VERSION_msbuild-native ?= "15.4"
 
-LAYERSERIES_COMPAT_mono = "sumo thud warrior"
+LAYERSERIES_COMPAT_mono = "sumo thud warrior zeus"

--- a/recipes-mono/mono-helloworld/mono-helloworld.inc
+++ b/recipes-mono/mono-helloworld/mono-helloworld.inc
@@ -12,7 +12,7 @@ SRC_URI = "https://github.com/DynamicDevices/mono-helloworld/releases/download/v
 inherit autotools-brokensep
 inherit mono
 
-DEPENDS_${PN} = "mono"
+DEPENDS = "mono"
 RDEPENDS_${PN} = "mono"
 
 EDEPENDS_X11 = "libgdiplus"

--- a/recipes-mono/mono/mono-5.xx.inc
+++ b/recipes-mono/mono/mono-5.xx.inc
@@ -101,6 +101,7 @@ FILES_${PN}-api-4.6.2			+= " ${libdir}/mono/4.6.2-api/*"
 FILES_${PN}-api-4.7			+= " ${libdir}/mono/4.7-api/*"
 
 RDEPENDS_${PN} =+ "bash" 
+RDEPENDS_${PN}-dev =+ "bash"
 
 # Workaround for observed race in `make install`
 PARALLEL_MAKEINST=""

--- a/recipes-mono/mono/mono-5.xx.inc
+++ b/recipes-mono/mono/mono-5.xx.inc
@@ -30,6 +30,7 @@ FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"
 inherit autotools-brokensep
 inherit pkgconfig
 inherit gettext
+inherit pythonnative
 
 # avoids build breaks when using no-static-libs.inc
 DISABLE_STATIC = ""

--- a/recipes-mono/mono/mono-5.xx.inc
+++ b/recipes-mono/mono/mono-5.xx.inc
@@ -100,8 +100,9 @@ FILES_${PN}-api-4.6.1			+= " ${libdir}/mono/4.6.1-api/*"
 FILES_${PN}-api-4.6.2			+= " ${libdir}/mono/4.6.2-api/*"
 FILES_${PN}-api-4.7			+= " ${libdir}/mono/4.7-api/*"
 
-RDEPENDS_${PN} =+ "bash" 
+RDEPENDS_${PN} =+ "bash zlib"
 RDEPENDS_${PN}-dev =+ "bash"
+RDEPENDS_${PN}-libs =+ "zlib"
 
 # Workaround for observed race in `make install`
 PARALLEL_MAKEINST=""


### PR DESCRIPTION
Hey there,

we tried to build mono using the latest zeus version of poky. This revealed several QA issues that will be fixed with this patches. Also python is used instead of perl for some task now. This will be also added.

```
$ bitbake mono
Parsing recipes: 100% |##############################################################################################################################################| Time: 0:00:40
Parsing of 1649 .bb files complete (0 cached, 1649 parsed). 2371 targets, 67 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.44.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "x86_64-poky-linux"
MACHINE              = "qemux86-64"
DISTRO               = "poky"
DISTRO_VERSION       = "3.0.1"
TUNE_FEATURES        = "m64 core2"
TARGET_FPU           = ""
meta
meta-poky
meta-yocto-bsp       = "zeus:cf92a2d567260b91a259652bad0ecd790750f710"
meta-oe              = "zeus:e855ecc6d35677e79780adc57b2552213c995731"
meta-mono            = "master:f4a733ed792372115e021fd5dfd916b02dadd3e0"

Initialising tasks: 100% |###########################################################################################################################################| Time: 0:00:01
Sstate summary: Wanted 531 Found 522 Missed 9 Current 0 (98% match, 0% complete)
NOTE: Executing Tasks
NOTE: Setscene tasks completed
NOTE: Tasks Summary: Attempted 2163 tasks of which 2134 didn't need to be rerun and all succeeded.
```