### PR TITLE
Python3 switch

### DIFF
--- a/recipes-mono/mono/mono-5.xx.inc
+++ b/recipes-mono/mono/mono-5.xx.inc
@@ -30,7 +30,7 @@ FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"
 inherit autotools-brokensep
 inherit pkgconfig
 inherit gettext
-inherit pythonnative
+inherit python3native
 
 # avoids build breaks when using no-static-libs.inc
 DISABLE_STATIC = ""

--- a/recipes-mono/mono/mono-6.xx.inc
+++ b/recipes-mono/mono/mono-6.xx.inc
@@ -29,6 +29,7 @@ FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"
 inherit autotools-brokensep
 inherit pkgconfig
 inherit gettext
+inherit python3native
 
 # avoids build breaks when using no-static-libs.inc
 DISABLE_STATIC = ""


### PR DESCRIPTION
Poky is in the middle of switching from python 2 to python 3. Python 2 is no longer available in poky master. Therefor mono 5 will no longer build.
To enable building mono 5 and 6 these changes are required. 