### PR TITLE
Python3 fixes and minor mono-6.xx.inc fix

### DIFF
--- a/recipes-mono/mono/mono-5.xx.inc
+++ b/recipes-mono/mono/mono-5.xx.inc
@@ -9,6 +9,7 @@ DEPENDS = "zlib"
 SRC_URI = "http://download.mono-project.com/sources/mono/mono-${PV}.tar.bz2 \
            file://dllmap-config.in.diff \
            file://0002-prevent-threadpool-exception5-test-hanging.patch \
+           file://0003-mono-use-python3-instead-of-python.patch \
 "
 
 # Add this patch into SRC_URI when testing projects

--- a/recipes-mono/mono/mono-5.xx/0003-mono-use-python3-instead-of-python.patch
+++ b/recipes-mono/mono/mono-5.xx/0003-mono-use-python3-instead-of-python.patch
@@ -1,0 +1,166 @@
+From b23dc637abcb049fca335d3afd31a02cf87a309b Mon Sep 17 00:00:00 2001
+From: Kraag Gorim <kraaggorim@gmail.com>
+Date: Thu, 6 Feb 2020 16:21:46 +0100
+Subject: [PATCH] mono: use python3 instead of python
+
+Replace all calls for python with a variable and switch from python
+version 2 to version 3.
+---
+ acceptance-tests/Makefile.in    | 9 +++++----
+ mono/mini/Makefile.am           | 4 +++-
+ mono/mini/Makefile.am.in        | 4 +++-
+ mono/mini/Makefile.in           | 3 ++-
+ mono/mini/genmdesc.py           | 2 +-
+ mono/tests/Makefile.am          | 3 ++-
+ mono/utils/jemalloc/Makefile.in | 9 +++++----
+ 7 files changed, 21 insertions(+), 13 deletions(-)
+
+diff --git a/acceptance-tests/Makefile.in b/acceptance-tests/Makefile.in
+index 9b9b777..7b2313d 100644
+--- a/acceptance-tests/Makefile.in
++++ b/acceptance-tests/Makefile.in
+@@ -265,6 +265,7 @@ PATH_SEPARATOR = @PATH_SEPARATOR@
+ PIDTYPE = @PIDTYPE@
+ PKG_CONFIG = @PKG_CONFIG@
+ PLATFORM_AOT_SUFFIX = @PLATFORM_AOT_SUFFIX@
++PYTHON = "python3"
+ RANLIB = @RANLIB@
+ SEARCHSEP = @SEARCHSEP@
+ SED = @SED@
+@@ -5770,19 +5771,19 @@ reset:
+ 
+ __bump-version-%:
+ 	@if [ "$(REV)" = "" ]; then echo "Usage: make bump-version-$* REV=<ref>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $(REV)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-branch-%:
+ 	@if [ "$(BRANCH)" = "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+ 	@if [ "$(REMOTE_BRANCH)" == "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to switch to $(BRANCH) $(REMOTE BRANCH)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-current-version-%:
+ 	REV=$(shell cd $(ACCEPTANCE_TESTS_PATH)/$* && git log -1 --pretty=format:%H); \
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
+ 	if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $$REV:" | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ $(eval $(call ValidateVersionTemplate,benchmarker,BENCHMARKER))
+diff --git a/mono/mini/Makefile.am b/mono/mini/Makefile.am
+index f6f85d0..f88e667 100644
+--- a/mono/mini/Makefile.am
++++ b/mono/mini/Makefile.am
+@@ -683,9 +683,11 @@ generics-variant-types.dll: generics-variant-types.il
+ MemoryIntrinsics.dll: MemoryIntrinsics.il
+ 	$(ILASM) -dll -output=$@ $<
+ 
++PYTHON = python3
++
+ GENMDESC_OPTS=
+ 
+-GENMDESC_PRG=python $(srcdir)/genmdesc.py $(target_define) $(srcdir)
++GENMDESC_PRG=$(PYTHON) $(srcdir)/genmdesc.py $(target_define) $(srcdir)
+ 
+ cpu-wasm.h: mini-ops.h cpu-wasm.md
+ 	$(GENMDESC_PRG) cpu-wasm.h wasm_desc $(srcdir)/cpu-wasm.md
+diff --git a/mono/mini/Makefile.am.in b/mono/mini/Makefile.am.in
+index f6f85d0..f88e667 100755
+--- a/mono/mini/Makefile.am.in
++++ b/mono/mini/Makefile.am.in
+@@ -683,9 +683,11 @@ generics-variant-types.dll: generics-variant-types.il
+ MemoryIntrinsics.dll: MemoryIntrinsics.il
+ 	$(ILASM) -dll -output=$@ $<
+ 
++PYTHON = python3
++
+ GENMDESC_OPTS=
+ 
+-GENMDESC_PRG=python $(srcdir)/genmdesc.py $(target_define) $(srcdir)
++GENMDESC_PRG=$(PYTHON) $(srcdir)/genmdesc.py $(target_define) $(srcdir)
+ 
+ cpu-wasm.h: mini-ops.h cpu-wasm.md
+ 	$(GENMDESC_PRG) cpu-wasm.h wasm_desc $(srcdir)/cpu-wasm.md
+diff --git a/mono/mini/Makefile.in b/mono/mini/Makefile.in
+index 52f3fcf..0fe413a 100644
+--- a/mono/mini/Makefile.in
++++ b/mono/mini/Makefile.in
+@@ -1146,8 +1146,9 @@ libmonosgen_2_0_la_LDFLAGS = $(libmonoldflags) $(monobin_platform_ldflags)
+ libmonoincludedir = $(includedir)/mono-$(API_VER)/mono/jit
+ libmonoinclude_HEADERS = jit.h
+ CSFLAGS = -unsafe -nowarn:0219,0169,0414,0649,0618
++PYTHON = python3
+ GENMDESC_OPTS = 
+-GENMDESC_PRG = python $(srcdir)/genmdesc.py $(target_define) $(srcdir)
++GENMDESC_PRG = $(PYTHON) $(srcdir)/genmdesc.py $(target_define) $(srcdir)
+ LLVM_AOT_RUNTIME_OPTS = $(if $(LLVM),--llvm,)
+ GSHAREDVT_RUNTIME_OPTS = $(if $(GSHAREDVT),-O=gsharedvt,)
+ fullaot_regtests = $(regtests)
+diff --git a/mono/mini/genmdesc.py b/mono/mini/genmdesc.py
+index 987332b..3691c9d 100755
+--- a/mono/mini/genmdesc.py
++++ b/mono/mini/genmdesc.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ #
+ # This tool is used to generate the cpu-<ARCH>.h files used by the JIT. The input is the
+diff --git a/mono/tests/Makefile.am b/mono/tests/Makefile.am
+index 2600999..a9512c2 100755
+--- a/mono/tests/Makefile.am
++++ b/mono/tests/Makefile.am
+@@ -2397,8 +2397,9 @@ coreclr-gcstress:
+ 
+ # Tests for the Mono lldb plugin
+ EXTRA_DIST += test_lldb.py test-lldb.cs
++PYTHON = python3
+ test-lldb: test-lldb.exe
+-	python test_lldb.py $(JITTEST_PROG)
++	$(PYTHON) test_lldb.py $(JITTEST_PROG)
+ 
+ noinst_LTLIBRARIES = libtest.la
+ 
+diff --git a/mono/utils/jemalloc/Makefile.in b/mono/utils/jemalloc/Makefile.in
+index 997cb07..cd53917 100644
+--- a/mono/utils/jemalloc/Makefile.in
++++ b/mono/utils/jemalloc/Makefile.in
+@@ -269,6 +269,7 @@ PATH_SEPARATOR = @PATH_SEPARATOR@
+ PIDTYPE = @PIDTYPE@
+ PKG_CONFIG = @PKG_CONFIG@
+ PLATFORM_AOT_SUFFIX = @PLATFORM_AOT_SUFFIX@
++PYTHON = python3
+ RANLIB = @RANLIB@
+ SEARCHSEP = @SEARCHSEP@
+ SED = @SED@
+@@ -667,19 +668,19 @@ reset:
+ 
+ __bump-version-%:
+ 	@if [ "$(REV)" = "" ]; then echo "Usage: make bump-version-$* REV=<ref>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $(REV)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-branch-%:
+ 	@if [ "$(BRANCH)" = "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+ 	@if [ "$(REMOTE_BRANCH)" == "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to switch to $(BRANCH) $(REMOTE BRANCH)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-current-version-%:
+ 	REV=$(shell cd $(ACCEPTANCE_TESTS_PATH)/$* && git log -1 --pretty=format:%H); \
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
+ 	if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $$REV:" | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ $(eval $(call ValidateVersionTemplate,jemalloc,JEMALLOC))
+-- 
+2.24.0
+

--- a/recipes-mono/mono/mono-6.xx.inc
+++ b/recipes-mono/mono/mono-6.xx.inc
@@ -8,6 +8,7 @@ DEPENDS = "zlib"
 
 SRC_URI = "http://download.mono-project.com/sources/mono/mono-${PV}.tar.xz \
            file://dllmap-config.in.diff \
+           file://0003-mono-use-python3-instead-of-python.patch \
 "
 
 # Add this patch into SRC_URI when testing projects

--- a/recipes-mono/mono/mono-6.xx.inc
+++ b/recipes-mono/mono/mono-6.xx.inc
@@ -100,8 +100,9 @@ FILES_${PN}-api-4.6.1			+= " ${libdir}/mono/4.6.1-api/*"
 FILES_${PN}-api-4.6.2			+= " ${libdir}/mono/4.6.2-api/*"
 FILES_${PN}-api-4.7			+= " ${libdir}/mono/4.7-api/*"
 
-RDEPENDS_${PN} =+ "bash" 
-RDEPENDS_${PN}-dev =+ "bash" 
+RDEPENDS_${PN} =+ "bash zlib"
+RDEPENDS_${PN}-dev =+ "bash"
+RDEPENDS_${PN}-libs =+ "zlib"
 
 # Workaround for observed race in `make install`
 PARALLEL_MAKEINST=""

--- a/recipes-mono/mono/mono-6.xx.inc
+++ b/recipes-mono/mono/mono-6.xx.inc
@@ -23,7 +23,7 @@ def mono_workspace_version (d):
 
 S = "${WORKDIR}/mono-${@mono_workspace_version(d)}"
 
-FILESPATH =. "${FILE_DIRNAME}/mono-5.xx:"
+FILESPATH =. "${FILE_DIRNAME}/mono-6.xx:"
 FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"
 
 inherit autotools-brokensep

--- a/recipes-mono/mono/mono-6.xx/0003-mono-use-python3-instead-of-python.patch
+++ b/recipes-mono/mono/mono-6.xx/0003-mono-use-python3-instead-of-python.patch
@@ -1,0 +1,181 @@
+From 19ff4cd531cbf3b4ad9d271f122f7d40a5e07b96 Mon Sep 17 00:00:00 2001
+From: Kraag Gorim <kraaggorim@gmail.com>
+Date: Thu, 6 Feb 2020 11:01:13 +0100
+Subject: [PATCH] mono: use python3 instead of python
+
+Replace all calls for python with a variable and switch from python
+version 2 to version 3.
+---
+ acceptance-tests/Makefile.in    | 9 +++++----
+ mono/mini/Makefile.am           | 4 +++-
+ mono/mini/Makefile.am.in        | 4 +++-
+ mono/mini/Makefile.in           | 3 ++-
+ mono/mini/genmdesc.py           | 2 +-
+ mono/tests/Makefile.am          | 3 ++-
+ mono/utils/jemalloc/Makefile.in | 9 +++++----
+ netcore/Makefile                | 3 ++-
+ 8 files changed, 23 insertions(+), 14 deletions(-)
+
+diff --git a/acceptance-tests/Makefile.in b/acceptance-tests/Makefile.in
+index 930a27e68..1f0d44981 100644
+--- a/acceptance-tests/Makefile.in
++++ b/acceptance-tests/Makefile.in
+@@ -305,6 +305,7 @@ PIDTYPE = @PIDTYPE@
+ PKG_CONFIG = @PKG_CONFIG@
+ PLATFORM_AOT_PREFIX = @PLATFORM_AOT_PREFIX@
+ PLATFORM_AOT_SUFFIX = @PLATFORM_AOT_SUFFIX@
++PYTHON = "python3"
+ RANLIB = @RANLIB@
+ RID = @RID@
+ SEARCHSEP = @SEARCHSEP@
+@@ -5839,19 +5840,19 @@ reset:
+ 
+ __bump-version-%:
+ 	@if [ "$(REV)" = "" ]; then echo "Usage: make bump-version-$* REV=<ref>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $(REV)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-branch-%:
+ 	@if [ "$(BRANCH)" = "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+ 	@if [ "$(REMOTE_BRANCH)" == "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to switch to $(BRANCH) $(REMOTE BRANCH)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-current-version-%:
+ 	REV=$(shell cd $(ACCEPTANCE_TESTS_PATH)/$* && git log -1 --pretty=format:%H); \
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
+ 	if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $$REV:" | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ $(eval $(call ValidateVersionTemplate,benchmarker,BENCHMARKER))
+diff --git a/mono/mini/Makefile.am b/mono/mini/Makefile.am
+index ef744067c..662e8b3ec 100644
+--- a/mono/mini/Makefile.am
++++ b/mono/mini/Makefile.am
+@@ -820,9 +820,11 @@ generics-variant-types.dll: generics-variant-types.il
+ MemoryIntrinsics.dll: MemoryIntrinsics.il
+ 	$(ILASM) -dll -output=$@ $<
+ 
++PYTHON = python3
++
+ GENMDESC_OPTS=
+ 
+-GENMDESC_PRG=python $(srcdir)/genmdesc.py $(target_define) $(srcdir)
++GENMDESC_PRG=$(PYTHON) $(srcdir)/genmdesc.py $(target_define) $(srcdir)
+ 
+ cpu-wasm.h: mini-ops.h cpu-wasm.md $(srcdir)/genmdesc.py
+ 	$(GENMDESC_PRG) cpu-wasm.h wasm_desc $(srcdir)/cpu-wasm.md
+diff --git a/mono/mini/Makefile.am.in b/mono/mini/Makefile.am.in
+index ef744067c..662e8b3ec 100755
+--- a/mono/mini/Makefile.am.in
++++ b/mono/mini/Makefile.am.in
+@@ -820,9 +820,11 @@ generics-variant-types.dll: generics-variant-types.il
+ MemoryIntrinsics.dll: MemoryIntrinsics.il
+ 	$(ILASM) -dll -output=$@ $<
+ 
++PYTHON = python3
++
+ GENMDESC_OPTS=
+ 
+-GENMDESC_PRG=python $(srcdir)/genmdesc.py $(target_define) $(srcdir)
++GENMDESC_PRG=$(PYTHON) $(srcdir)/genmdesc.py $(target_define) $(srcdir)
+ 
+ cpu-wasm.h: mini-ops.h cpu-wasm.md $(srcdir)/genmdesc.py
+ 	$(GENMDESC_PRG) cpu-wasm.h wasm_desc $(srcdir)/cpu-wasm.md
+diff --git a/mono/mini/Makefile.in b/mono/mini/Makefile.in
+index 4063da3bd..b559ad90f 100644
+--- a/mono/mini/Makefile.in
++++ b/mono/mini/Makefile.in
+@@ -1360,8 +1360,9 @@ libmonoincludedir = $(includedir)/mono-$(API_VER)/mono/jit
+ # They should be wrapped in MONO_BEGIN_DECLS / MONO_END_DECLS.
+ libmonoinclude_HEADERS = jit.h
+ CSFLAGS = -unsafe -nowarn:0219,0169,0414,0649,0618
++PYTHON = python3
+ GENMDESC_OPTS = 
+-GENMDESC_PRG = python $(srcdir)/genmdesc.py $(target_define) $(srcdir)
++GENMDESC_PRG = $(PYTHON) $(srcdir)/genmdesc.py $(target_define) $(srcdir)
+ LLVM_AOT_RUNTIME_OPTS = $(if $(LLVM),--llvm,)
+ @AMD64_FALSE@LLVM_AOT_COMPILER_OPTS = 
+ @AMD64_TRUE@LLVM_AOT_COMPILER_OPTS = $(if $(LLVM),llvmllc=-mattr=+sse3,)
+diff --git a/mono/mini/genmdesc.py b/mono/mini/genmdesc.py
+index 79a110bfb..7a20260e8 100755
+--- a/mono/mini/genmdesc.py
++++ b/mono/mini/genmdesc.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ #
+ # This tool is used to generate the cpu-<ARCH>.h files used by the JIT. The input is the
+diff --git a/mono/tests/Makefile.am b/mono/tests/Makefile.am
+index d88fbff36..487d0cbe0 100755
+--- a/mono/tests/Makefile.am
++++ b/mono/tests/Makefile.am
+@@ -3155,8 +3155,9 @@ coreclr-gcstress:
+ 
+ # Tests for the Mono lldb plugin
+ EXTRA_DIST += test_lldb.py test-lldb.cs
++PYTHON = python3
+ test-lldb: test-lldb.exe
+-	python test_lldb.py $(JITTEST_PROG)
++	$(PYTHON) test_lldb.py $(JITTEST_PROG)
+ 
+ if !ENABLE_MSVC_ONLY
+ 
+diff --git a/mono/utils/jemalloc/Makefile.in b/mono/utils/jemalloc/Makefile.in
+index 3249ce833..a5421676b 100644
+--- a/mono/utils/jemalloc/Makefile.in
++++ b/mono/utils/jemalloc/Makefile.in
+@@ -302,6 +302,7 @@ PIDTYPE = @PIDTYPE@
+ PKG_CONFIG = @PKG_CONFIG@
+ PLATFORM_AOT_PREFIX = @PLATFORM_AOT_PREFIX@
+ PLATFORM_AOT_SUFFIX = @PLATFORM_AOT_SUFFIX@
++PYTHON = python3
+ RANLIB = @RANLIB@
+ RID = @RID@
+ SEARCHSEP = @SEARCHSEP@
+@@ -729,19 +730,19 @@ reset:
+ 
+ __bump-version-%:
+ 	@if [ "$(REV)" = "" ]; then echo "Usage: make bump-version-$* REV=<ref>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $(REV)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-branch-%:
+ 	@if [ "$(BRANCH)" = "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+ 	@if [ "$(REMOTE_BRANCH)" == "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to switch to $(BRANCH) $(REMOTE BRANCH)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-current-version-%:
+ 	REV=$(shell cd $(ACCEPTANCE_TESTS_PATH)/$* && git log -1 --pretty=format:%H); \
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
+ 	if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $$REV:" | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ $(eval $(call ValidateVersionTemplate,jemalloc,JEMALLOC))
+diff --git a/netcore/Makefile b/netcore/Makefile
+index 72eb883a9..4a8ff64c6 100644
+--- a/netcore/Makefile
++++ b/netcore/Makefile
+@@ -19,7 +19,8 @@ ifeq ($(HOST_PLATFORM),win32)
+ PLATFORM_AOT_SUFFIX := .dll
+ PLATFORM_AOT_PREFIX :=
+ NETCORESDK_EXT = zip
+-UNZIPCMD = python -c "import zipfile,sys; zipfile.ZipFile(sys.argv[1], 'r').extractall()"
++PYTHON = "python3"
++UNZIPCMD = $(PYTHON) -c "import zipfile,sys; zipfile.ZipFile(sys.argv[1], 'r').extractall()"
+ XUNIT_FLAGS = -notrait category=nonwindowstests @../../../../CoreFX.issues_windows.rsp
+ TESTS_PLATFORM = Windows_NT.x64
+ ON_RUNTIME_EXTRACT = chmod -R 755 {host,shared,./dotnet}
+-- 
+2.24.0
+


### PR DESCRIPTION
This might be not a nice and complete approach, but building mono and mono-native in version 5 and 6 works with poky master and openembedded master.

```
$ bitbake mono
Loading cache: 100% |###################################################################################################| Time: 0:00:00
Loaded 2416 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.44.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "x86_64-poky-linux"
MACHINE              = "qemux86-64"
DISTRO               = "poky"
DISTRO_VERSION       = "3.0+snapshot-20200207"
TUNE_FEATURES        = "m64 core2"
TARGET_FPU           = ""
meta
meta-poky
meta-yocto-bsp       = "master:fb9d7c967025dee5cff9e73eb4fcc6ddfc0bf2ea"
meta-oe              = "master-next:bceff42e42b0fc937d772b2f50d55b44bfe47ff8"
meta-mono            = "python3-fix:2faf8b7a84f982c962c253410558424f41981d6a"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:01
Sstate summary: Wanted 195 Found 188 Missed 7 Current 558 (96% match, 99% complete)
NOTE: Executing Tasks
NOTE: Setscene tasks completed
NOTE: Tasks Summary: Attempted 2400 tasks of which 2388 didn't need to be rerun and all succeeded.
```