### PR TITLE
mono: Workaround libmono-native.so packaging issue

### DIFF
--- a/recipes-mono/mono/mono-6.xx.inc
+++ b/recipes-mono/mono/mono-6.xx.inc
@@ -76,7 +76,7 @@ PACKAGES += "${PN}-lldb "
 PACKAGES += "${PN} "
 
 FILES_${PN}				= "${sysconfdir}/* ${bindir}/* ${libdir}/*.so*"
-FILES_${PN}-libs			= "${libdir}/libMono*.so ${libdir}/libikvm-native.so ${libdir}/libmono-btls-shared.so"
+FILES_${PN}-libs			= "${libdir}/libMono*.so ${libdir}/libmono-native.so ${libdir}/libikvm-native.so ${libdir}/libmono-btls-shared.so"
 FILES_${PN}-lldb                        = "${libdir}/mono/lldb/*"
 FILES_${PN}-libs-2.0                    = "${libdir}/mono/2.0/* ${libdir}/mono/2.0-api/*"
 FILES_${PN}-libs-3.5                    = "${libdir}/mono/3.5/* ${libdir}/mono/3.5-api/*"

--- a/recipes-mono/mono/mono_6.8.0.96.bb
+++ b/recipes-mono/mono/mono_6.8.0.96.bb
@@ -7,3 +7,5 @@ SRC_URI += "file://shm_open-test-crosscompile.diff"
 
 PACKAGES += "${PN}-profiler "
 FILES_${PN}-profiler += " ${datadir}/mono-2.0/mono/profiler/*"
+
+INSANE_SKIP_${PN}-libs += "dev-so"


### PR DESCRIPTION
Mono is expecting /usr/lib/libmono-native.so but this
was being packaged in mono-dev. When we package in the
mono-libs package we get a QA error as symlinks should
be in mono-dev.

I've not been able to change the build to require a
different library name, as this breaks mono-native
build so for now have packaged the .so symlink in
mono-libs and disabled the QA dev-so check.

Signed-off-by: Alex J Lennon <ajlennon@dynamicdevices.co.uk>