### PR TITLE
mono-native_6.8.0.96: Fix issue initialising Windows Form. Issue #18

### DIFF
--- a/recipes-mono/mono/mono-6.8.0.96/0001-patch-XplatUIX11-cursor.diff
+++ b/recipes-mono/mono/mono-6.8.0.96/0001-patch-XplatUIX11-cursor.diff
@@ -1,0 +1,15 @@
+diff -ur mono-6.8.0.96.org/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs mono-6.8.0.96/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+--- mono-6.8.0.96.org/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs	2020-01-15 07:46:01.000000000 +0000
++++ mono-6.8.0.96/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs	2020-02-08 21:22:11.059830600 +0000
+@@ -3091,6 +3091,11 @@
+ 				return IntPtr.Zero;
+ 			}
+ 
++			if(width == 0 || height == 0) {
++                          width = bitmap.Width;
++                          height = bitmap.Height;
++                        }
++
+ 			// Win32 only allows creation cursors of a certain size
+ 			if ((bitmap.Width != width) || (bitmap.Width != height)) {
+ 				cursor_bitmap = new Bitmap(bitmap, new Size(width, height));

--- a/recipes-mono/mono/mono-native_6.8.0.96.bb
+++ b/recipes-mono/mono/mono-native_6.8.0.96.bb
@@ -2,3 +2,6 @@ require mono-6.xx.inc
 require mono-mit-bsd-6xx.inc
 require mono-native-6.xx-base.inc
 require mono-${PV}.inc
+
+SRC_URI += "file://0001-patch-XplatUIX11-cursor.diff"
+


### PR DESCRIPTION
Issue with DefineCursor causes an exception to be thrown.

@see: https://github.com/mono/mono/issues/13049

Signed-off-by: Alex J Lennon <ajlennon@dynamicdevices.co.uk>