### PR TITLE
mono-6: expand python3 patch

### DIFF
--- a/recipes-mono/mono/mono-6.xx/0003-mono-use-python3-instead-of-python.patch
+++ b/recipes-mono/mono/mono-6.xx/0003-mono-use-python3-instead-of-python.patch
@@ -14,7 +14,9 @@ version 2 to version 3.
  mono/tests/Makefile.am          | 3 ++-
  mono/utils/jemalloc/Makefile.in | 9 +++++----
  netcore/Makefile                | 3 ++-
- 8 files changed, 23 insertions(+), 14 deletions(-)
+ scripts/submodules/versions.mk  | 9 +++++----
+ scripts/submodules/versions.py  | 2 +-
+ 10 files changed, 29 insertions(+), 19 deletions(-)
 
 diff --git a/acceptance-tests/Makefile.in b/acceptance-tests/Makefile.in
 index 930a27e68..1f0d44981 100644
@@ -176,6 +178,50 @@ index 72eb883a9..4a8ff64c6 100644
  XUNIT_FLAGS = -notrait category=nonwindowstests @../../../../CoreFX.issues_windows.rsp
  TESTS_PLATFORM = Windows_NT.x64
  ON_RUNTIME_EXTRACT = chmod -R 755 {host,shared,./dotnet}
+diff --git a/scripts/submodules/versions.mk b/scripts/submodules/versions.mk
+index 899b09de0..f1b9ccdfe 100644
+--- a/scripts/submodules/versions.mk
++++ b/scripts/submodules/versions.mk
+@@ -4,6 +4,7 @@
+ #
+ 
+ SCRIPT=$(top_srcdir)/scripts/submodules/versions.py
++PYTHON=python3
+ 
+ # usage $(call ValidateVersionTemplate (name,MAKEFILE VAR,repo name))
+ # usage $(call ValidateVersionTemplate (mono,MONO,mono))
+@@ -106,17 +107,17 @@ reset:
+ 
+ __bump-version-%:
+ 	@if [ "$(REV)" = "" ]; then echo "Usage: make bump-version-$* REV=<ref>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $(REV)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $(REV)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-branch-%:
+ 	@if [ "$(BRANCH)" = "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+ 	@if [ "$(REMOTE_BRANCH)" == "" ]; then echo "Usage: make bump-branch-$* BRANCH=<branch> REMOTE_BRANCH=<remote branch>"; exit 1; fi
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-branch $* $(BRANCH)
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-remote-branch $* $(REMOTE_BRANCH)
+ 	@if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to switch to $(BRANCH) $(REMOTE BRANCH)." | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+ 
+ __bump-current-version-%:
+ 	REV=$(shell cd $(ACCEPTANCE_TESTS_PATH)/$* && git log -1 --pretty=format:%H); \
+-	python $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
++	$(PYTHON) $(SCRIPT) $(SUBMODULES_CONFIG_FILE) set-rev $* $$REV; \
+ 	if [ "$(COMMIT)" = "1" ]; then echo "[submodules] Bump $* to pick up $$REV:" | git commit -F - $(SUBMODULES_CONFIG_FILE); fi
+diff --git a/scripts/submodules/versions.py b/scripts/submodules/versions.py
+index 5252ee583..44994d23f 100755
+--- a/scripts/submodules/versions.py
++++ b/scripts/submodules/versions.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ import sys
+ import json
 -- 
 2.24.0
 


### PR DESCRIPTION
Change versions.mk and versions.py in scripts/submodules to also use python
3. This is used by acceptance tests and jemalloc.

So I encountered another area where python is used in our product build. The patch just got expanded similar to the other areas.

```
$ bitbake mono
Parsing recipes: 100% |###############################################################################################################################################| Time: 0:00:44
Parsing of 1678 .bb files complete (0 cached, 1678 parsed). 2418 targets, 76 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.44.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "x86_64-poky-linux"
MACHINE              = "qemux86-64"
DISTRO               = "poky"
DISTRO_VERSION       = "3.0+snapshot-20200211"
TUNE_FEATURES        = "m64 core2"
TARGET_FPU           = ""
meta
meta-poky
meta-yocto-bsp       = "master:34535f3e0ca6f6e37e6457fc800dfbfff64d9298"
meta-oe              = "master:611b0c707aa889b1b3880687334b6dd0fd69479b"
meta-mono            = "python-test-fix:157e26e190574437e2c0740bc244e675fbfe8606"

NOTE: Fetching uninative binary shim from http://downloads.yoctoproject.org/releases/uninative/2.7/x86_64-nativesdk-libc.tar.xz;sha256sum=9498d8bba047499999a7310ac2576d0796461184965
351a56f6d32c888a1f216
Initialising tasks: 100% |############################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 755 Found 0 Missed 755 Current 0 (0% match, 0% complete)
NOTE: Executing Tasks
NOTE: Setscene tasks completed
NOTE: Tasks Summary: Attempted 2409 tasks of which 0 didn't need to be rerun and all succeeded.
```