### PR TITLE
msbuild: Apply do_install_append() to native mode

### DIFF
--- a/recipes-mono/msbuild/msbuild_15.4.bb
+++ b/recipes-mono/msbuild/msbuild_15.4.bb
@@ -54,7 +54,7 @@ do_install () {
 	rm -rf ${D}${libdir}/mono/xbuild/15.0/Imports/Microsoft.Common.props
 }
 
-do_install_append_class-target() {
+do_install_append() {
 	install -d -m0755 ${D}${libdir}/mono/msbuild/15.0/bin/Roslyn
 	install -m0755 ${S}/bin/Release-MONO/AnyCPU/Unix/Unix_Deployment/Roslyn/* ${D}${libdir}/mono/msbuild/15.0/bin/Roslyn/
 }


### PR DESCRIPTION
When used with Mono 5.20 or 6.x, projects using msbuild complain
about missing directories that previously were conflicting with
Mono.

Signed-off-by: Böszörményi Zoltán <zboszor@pr.hu>