### PR TITLE
libgdiplus: Add package config for pango

### DIFF
--- a/recipes-mono/libgdiplus/libgdiplus-6.xx.inc
+++ b/recipes-mono/libgdiplus/libgdiplus-6.xx.inc
@@ -1,0 +1,14 @@
+PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} jpeg tiff gif exif pango"
+PACKAGECONFIG[jpeg] = "--with-libjpeg,--without-libjpeg,jpeg"
+PACKAGECONFIG[tiff] = "--with-libtiff,--without-libtiff,tiff"
+PACKAGECONFIG[gif] = "--with-libgif,--without-libgif,giflib"
+PACKAGECONFIG[exif] = "--with-libexif,--without-libexif,libexif"
+PACKAGECONFIG[pango] = "--with-pango,--without-pango,pango"
+PACKAGECONFIG[x11] = "--with-x11,--without-x11,virtual/libx11 libxft"
+
+DEPENDS =+ "cairo freetype fontconfig libpng"
+
+do_install_append() {
+# fix pkgconfig .pc file
+sed -i -e s#I${STAGING_DIR_HOST}#I#g ${D}${libdir}/pkgconfig/*.pc
+}

--- a/recipes-mono/libgdiplus/libgdiplus_6.0.2.bb
+++ b/recipes-mono/libgdiplus/libgdiplus_6.0.2.bb
@@ -1,5 +1,5 @@
 require libgdiplus-common.inc
-require libgdiplus.inc
+require libgdiplus-6.xx.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=e0a7dacaa67d7e24a32074fba736dc59"
 

--- a/recipes-mono/libgdiplus/libgdiplus_6.0.4.bb
+++ b/recipes-mono/libgdiplus/libgdiplus_6.0.4.bb
@@ -1,5 +1,5 @@
 require libgdiplus-common.inc
-require libgdiplus.inc
+require libgdiplus-6.xx.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=e0a7dacaa67d7e24a32074fba736dc59"
 


### PR DESCRIPTION
Using pango as font rendering engine adds support for many alphabets/scripts in libgdiplus.

This change is only supported by libgdiplus ≥ 6.0, so I'm not sure how to handle this. I could add a version-specific `libgdiplus-6.xx.inc` file. Feedback/ideas are welcome.