### PR TITLE
Changes for nativesdk support mono

### DIFF
--- a/recipes-mono/mono/mono-native-6.xx-base.inc
+++ b/recipes-mono/mono/mono-native-6.xx-base.inc
@@ -3,6 +3,9 @@ PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)}
 
 inherit native
 
+RPROVIDES += "nativesdk-mono"
+PROVIDES += "nativesdk-mono"
+
 do_compile() {
     make EXTERNAL_MCS="${S}/mcs/class/lib/monolite/basic.exe" EXTERNAL_RUNTIME="${S}/foo/bar/mono"
 }

--- a/recipes-mono/mono/mono_6.8.0.123.bb
+++ b/recipes-mono/mono/mono_6.8.0.123.bb
@@ -9,3 +9,4 @@ PACKAGES += "${PN}-profiler "
 FILES_${PN}-profiler += " ${datadir}/mono-2.0/mono/profiler/*"
 
 INSANE_SKIP_${PN}-libs += "dev-so"
+INSANE_SKIP_${PN} += "file-rdeps"


### PR DESCRIPTION
Upstream-Status: Backport

This is a back ported change to support on 6.8.0.123. This change will be removed once mono 6.10 upstream is fixed. 
https://github.com/mono/mono/issues/20299