### PR TITLE
Add msbuild 16.6

### DIFF
--- a/classes/mono.bbclass
+++ b/classes/mono.bbclass
@@ -1,7 +1,7 @@
 # Class for building C# packages. If your package is all-managed, add
 # PACKAGE_ARCH="all"
 
-DEPENDS += "mono-native mono"
+DEPENDS += "mono-native ca-certificates-native mono"
 RDEPENDS_${PN} += "mono"
 
 FILES_${PN} += "\
@@ -40,4 +40,5 @@ export NUGET_HTTP_CACHE_PATH="${WORKDIR}/mono-nuget-http-cache"
 
 do_configure_prepend() {
 	mkdir -p ${NUGET_PACKAGES} ${NUGET_HTTP_CACHE_PATH}
+	cert-sync --user ${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt
 }

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -19,7 +19,7 @@ PREFERRED_VERSION_libgdiplus-native ?= "6.0.4"
 PREFERRED_VERSION_nuget ?= "5.2.0"
 PREFERRED_VERSION_nuget-native ?= "5.2.0"
 
-PREFERRED_VERSION_msbuild ?= "15.4"
-PREFERRED_VERSION_msbuild-native ?= "15.4"
+PREFERRED_VERSION_msbuild ?= "16.6"
+PREFERRED_VERSION_msbuild-native ?= "16.6"
 
 LAYERSERIES_COMPAT_mono = "thud warrior zeus dunfell gatesgarth"

--- a/recipes-mono/dotnet/dotnet_3.1.11.bb
+++ b/recipes-mono/dotnet/dotnet_3.1.11.bb
@@ -1,0 +1,97 @@
+# Based on the recipe from from meta-iot-cloud
+# Copyright © 2016 Intel Corporation
+
+DESCRIPTION = ".NET Core Runtime, SDK & CLI tools"
+HOMEPAGE = "https://www.microsoft.com/net/core"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=9fc642ff452b28d62ab19b7eea50dfb9"
+
+COMPATIBLE_HOST ?= "(x86_64).*-linux"
+
+DEPENDS += "\
+    zlib \
+"
+
+RDEPENDS_${PN}_class-target += "\
+    lttng-ust \
+    libcurl \
+    krb5 \
+    libgssapi-krb5 \
+    libicuuc \
+    libicui18n \
+"
+
+RDEPENDS_${PN}_class-native += "\
+    curl-native \
+    krb5-native \
+    icu-native \
+    zlib-native \
+"
+
+HOST_FXR = "3.1.11"
+SHARED_FRAMEWORK = "3.1.11"
+SDK = "3.1.111"
+
+SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/d5d940c0-4c2f-4cbb-8d12-33bfb30c4db8/619b5be6e995cead6e9432134f903711/${BPN}-sdk-${SDK}-linux-x64.tar.gz"
+
+SRC_URI[sha256sum] = "a755b37aa328d160a39b39c0cd120ca7e318814ef024682bac49e75183952a89"
+
+S = "${WORKDIR}"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+python do_install () {
+    bb.build.exec_func("shell_do_install", d)
+    oe.path.make_relative_symlink(d.expand("${D}${bindir}/dotnet"))
+    oe.path.make_relative_symlink(d.expand("${D}${libdir}/libhostfxr.so"))
+}
+
+shell_do_install() {
+    install -d ${D}${bindir}
+    install -d ${D}${datadir}/dotnet
+    install -d ${D}${datadir}/dotnet/host/fxr
+    install -d ${D}${datadir}/dotnet/sdk
+    install -d ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App
+
+    install -m 0755 ${S}/dotnet ${D}${datadir}/dotnet
+    install -m 0644 ${S}/LICENSE.txt ${D}${datadir}/dotnet
+    install -m 0644 ${S}/ThirdPartyNotices.txt ${D}${datadir}/dotnet
+
+    cp -r ${S}/sdk/${SDK} ${D}${datadir}/dotnet/sdk
+    cp -r ${S}/host/fxr/${HOST_FXR} ${D}${datadir}/dotnet/host/fxr
+    cp -r ${S}/shared/Microsoft.NETCore.App/${SHARED_FRAMEWORK} ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App
+    cp -r ${S}/templates ${D}${datadir}/dotnet
+
+    install -d ${D}${libdir}
+
+    # Symlinks
+    ln -s ${D}${datadir}/dotnet/dotnet ${D}${bindir}/dotnet
+    ln -s ${D}${datadir}/dotnet/host/fxr/${HOST_FXR}/libhostfxr.so ${D}${libdir}/libhostfxr.so
+}
+
+FILES_${PN} = "\
+    ${bindir} \
+    ${libdir} \
+    ${datadir}/dotnet/dotnet \
+    ${datadir}/dotnet/*.txt \
+    ${datadir}/dotnet/host \
+    ${datadir}/dotnet/shared \
+"
+
+FILES_${PN}-dbg = "\
+    ${datadir}/dotnet/.debug \
+"
+
+FILES_${PN}-dev = "\
+    ${datadir}/dotnet/sdk \
+    ${datadir}/dotnet/templates \
+"
+
+RRECOMMENDS_dotnet-dev[nodeprrecs] = "1"
+
+INSANE_SKIP_${PN} = "already-stripped staticdev ldflags libdir"
+INSANE_SKIP_${PN}-dbg = "libdir"
+INSANE_SKIP_${PN}-dev = "libdir"
+
+BBCLASSEXTEND = "native"

--- a/recipes-mono/mono/mono-base.inc
+++ b/recipes-mono/mono/mono-base.inc
@@ -27,8 +27,6 @@ MONOLIBS = "\
     "
 
 do_install_append() {
-        cp -af --no-preserve=ownership \
-            ${STAGING_DIR_NATIVE}${sysconfdir}/${PN} ${D}${sysconfdir}
         install -d ${D}${libdir}/${PN}
         for lib in ${MONOLIBS}; do
             if [ -d "${STAGING_DIR_NATIVE}${libdir}/${PN}/$lib" ]; then

--- a/recipes-mono/mono/mono-native-6.xx-base.inc
+++ b/recipes-mono/mono/mono-native-6.xx-base.inc
@@ -19,3 +19,7 @@ mono_copy_libdir_mono() {
 }
 
 do_populate_sysroot[postfuncs] += " mono_copy_libdir_mono "
+
+do_install_append() {
+    sed "s|\$mono_libdir|${libdir}|g" -i ${D}${sysconfdir}/mono/config
+}

--- a/recipes-mono/msbuild/msbuild/0001-Copy-hostfxr.patch
+++ b/recipes-mono/msbuild/msbuild/0001-Copy-hostfxr.patch
@@ -1,0 +1,21 @@
+From be8f534947136661bfec11410da7767e92adb1f3 Mon Sep 17 00:00:00 2001
+From: Nicolas Jeker <n.jeker@gmx.net>
+Date: Fri, 22 Jan 2021 10:41:27 +0100
+Subject: [PATCH] Copy hostfxr
+
+---
+ eng/cibuild_bootstrapped_msbuild.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/eng/cibuild_bootstrapped_msbuild.sh b/eng/cibuild_bootstrapped_msbuild.sh
+index 759c75f..cfa3c28 100755
+--- a/eng/cibuild_bootstrapped_msbuild.sh
++++ b/eng/cibuild_bootstrapped_msbuild.sh
+@@ -61,6 +61,7 @@ function DownloadMSBuildForMono {
+     unzip -q "$msbuild_zip" -d "$artifacts_dir"
+     # rename just to make it obvious when reading logs!
+     mv $artifacts_dir/msbuild $mono_msbuild_dir
++    cp %libhostfxr% $artifacts_dir/mono-msbuild/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver/
+     sed -i 's#/sh$#/bash#' $artifacts_dir/mono-msbuild/msbuild
+     chmod +x $artifacts_dir/mono-msbuild/MSBuild.dll
+     rm "$msbuild_zip"

--- a/recipes-mono/msbuild/msbuild/0001-Don-t-try-to-run-pkill.patch
+++ b/recipes-mono/msbuild/msbuild/0001-Don-t-try-to-run-pkill.patch
@@ -1,0 +1,22 @@
+From 92f3ad0b176a1494d7225ea4b4062df9b40984e9 Mon Sep 17 00:00:00 2001
+From: Nicolas Jeker <n.jeker@delisys.ch>
+Date: Fri, 6 Nov 2020 11:19:38 +0100
+Subject: [PATCH] Don't try to run pkill
+
+---
+ eng/cibuild_bootstrapped_msbuild.sh | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/eng/cibuild_bootstrapped_msbuild.sh b/eng/cibuild_bootstrapped_msbuild.sh
+index c88445b..759c75f 100755
+--- a/eng/cibuild_bootstrapped_msbuild.sh
++++ b/eng/cibuild_bootstrapped_msbuild.sh
+@@ -107,8 +107,6 @@ if [ $host_type = "mono" ] ; then
+   fi
+ fi
+ 
+-pkill -9 -f VBCSCompiler.exe
+-
+ if [[ $build_stage1 == true ]];
+ then
+     "$_InitializeBuildTool" "$_InitializeBuildToolCommand" $extra_properties /bl mono/build/update_bundled_bits.proj || exit $?

--- a/recipes-mono/msbuild/msbuild/0002-Remove-myget-feeds-and-replace-with-AzDO-feeds.patch
+++ b/recipes-mono/msbuild/msbuild/0002-Remove-myget-feeds-and-replace-with-AzDO-feeds.patch
@@ -1,0 +1,41 @@
+From e2e4dfee543269ccb0a459263985b1c993feacec Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexander=20K=C3=B6plinger?= <alex.koeplinger@outlook.com>
+Date: Fri, 15 Jan 2021 12:39:49 +0100
+Subject: [PATCH] Remove myget feeds and replace with AzDO feeds
+
+---
+ NuGet.config | 18 +++---------------
+ 1 file changed, 3 insertions(+), 15 deletions(-)
+
+diff --git a/NuGet.config b/NuGet.config
+index 739b645cb7..ae05fb7e65 100644
+--- a/NuGet.config
++++ b/NuGet.config
+@@ -2,23 +2,11 @@
+ <configuration>
+   <packageSources>
+     <clear />
+-    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+-    <add key="darc-pub-dotnet-aspnetcore-tooling-5ecfad7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-tooling-5ecfad7e/nuget/v3/index.json" />
+-    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
+-    <add key="aspnetcore-release" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
+-    <add key="aspnetcore-dev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
+-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+-    <add key="dotnet-core2" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+-    <add key="container-tools" value="https://www.myget.org/F/container-tools-for-visual-studio/api/v3/index.json" />
+-    <add key="linux-musl-bootstrap-feed" value="https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180420-03/aspnet-inputs/index.json" />
+-    <add key="dotnet-msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
+     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+     <add key="arcade" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+-    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
+-    <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
+-    <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
+-    <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
++    <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
+   </packageSources>
+-</configuration>
++  <disabledPackageSources />
++</configuration>
+\ No newline at end of file

--- a/recipes-mono/msbuild/msbuild/mono-msbuild-dotnetbits-case.patch
+++ b/recipes-mono/msbuild/msbuild/mono-msbuild-dotnetbits-case.patch
@@ -1,0 +1,22 @@
+Index: xamarin-pkg-msbuild/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj
+===================================================================
+--- xamarin-pkg-msbuild.orig/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj
++++ xamarin-pkg-msbuild/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj
+@@ -1,6 +1,6 @@
+ <Project DefaultTargets="DeploySdksAndNuGets">
+     <Import Project="$(MSBuildThisFileDirectory)\..\common.props" />
+-    <Import Project="$(MSBuildThisFileDirectory)\..\DotnetBitsVersions.props" />
++    <Import Project="$(MSBuildThisFileDirectory)\..\DotNetBitsVersions.props" />
+ 
+     <PropertyGroup>
+         <HostOSName Condition="'$(HostOSName)' == ''">osx</HostOSName>
+Index: xamarin-pkg-msbuild/mono/build/update_bundled_bits.proj
+===================================================================
+--- xamarin-pkg-msbuild.orig/mono/build/update_bundled_bits.proj
++++ xamarin-pkg-msbuild/mono/build/update_bundled_bits.proj
+@@ -1,5 +1,5 @@
+ <Project DefaultTargets="FetchAndUpdateSdksAndNuGets">
+-    <Import Project="$(MSBuildThisFileDirectory)\DotnetBitsVersions.props" />
++    <Import Project="$(MSBuildThisFileDirectory)\DotNetBitsVersions.props" />
+ 
+     <Target Name="Build" DependsOnTargets="FetchAndUpdateSdksAndNuGets" />

--- a/recipes-mono/msbuild/msbuild/mono-msbuild-license-case.patch
+++ b/recipes-mono/msbuild/msbuild/mono-msbuild-license-case.patch
@@ -1,0 +1,58 @@
+Index: xamarin-pkg-msbuild/LICENSE
+===================================================================
+--- xamarin-pkg-msbuild.orig/LICENSE
++++ /dev/null
+@@ -1,24 +0,0 @@
+-The MIT License (MIT)
+-
+-Copyright (c) .NET Foundation and contributors
+-
+-All rights reserved.
+-
+-Permission is hereby granted, free of charge, to any person obtaining a copy
+-of this software and associated documentation files (the "Software"), to deal
+-in the Software without restriction, including without limitation the rights
+-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-copies of the Software, and to permit persons to whom the Software is
+-furnished to do so, subject to the following conditions:
+-
+-The above copyright notice and this permission notice shall be included in all
+-copies or substantial portions of the Software.
+-
+-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-SOFTWARE.
+-
+Index: xamarin-pkg-msbuild/license
+===================================================================
+--- /dev/null
++++ xamarin-pkg-msbuild/license
+@@ -0,0 +1,24 @@
++The MIT License (MIT)
++
++Copyright (c) .NET Foundation and contributors
++
++All rights reserved.
++
++Permission is hereby granted, free of charge, to any person obtaining a copy
++of this software and associated documentation files (the "Software"), to deal
++in the Software without restriction, including without limitation the rights
++to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++copies of the Software, and to permit persons to whom the Software is
++furnished to do so, subject to the following conditions:
++
++The above copyright notice and this permission notice shall be included in all
++copies or substantial portions of the Software.
++
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++SOFTWARE.
++

--- a/recipes-mono/msbuild/msbuild/mono-msbuild-no-hostfxr.patch
+++ b/recipes-mono/msbuild/msbuild/mono-msbuild-no-hostfxr.patch
@@ -1,0 +1,11 @@
+diff -rupN mono-msbuild.orig/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj mono-msbuild/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj
+--- mono-msbuild.orig/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj	2020-07-03 19:37:07.112979921 +0200
++++ mono-msbuild/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj	2020-07-03 19:37:59.966877151 +0200
+@@ -61,7 +61,6 @@
+             Targets="Restore;Build"
+             Properties="OutputDirectory=$(DotNetOverlayDirectory)\nuget-support\msbuild-bin"/>
+         
+-        <Exec Command="$(MSBuildThisFileDirectory)/../extract_and_copy_hostfxr.sh $(DotNetSdkVersionForLibHostFxr) $(MSBuildSdkResolverOutDir)" />
+         <Exec Command="$(MSBuildThisFileDirectory)/../get_sdk_files.sh $(DotNetOverlayDirectory)\msbuild-bin" />
+     </Target>
+ </Project>

--- a/recipes-mono/msbuild/msbuild/mono-msbuild-use-bash.patch
+++ b/recipes-mono/msbuild/msbuild/mono-msbuild-use-bash.patch
@@ -1,0 +1,42 @@
+Index: xamarin-pkg-msbuild/gen_build_info.sh
+===================================================================
+--- xamarin-pkg-msbuild.orig/gen_build_info.sh
++++ xamarin-pkg-msbuild/gen_build_info.sh
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ if [ $# -ne 1 ]; then
+ 	echo "Usage: $0 <filename.cs>"
+Index: xamarin-pkg-msbuild/mono/create_bootstrap.sh
+===================================================================
+--- xamarin-pkg-msbuild.orig/mono/create_bootstrap.sh
++++ xamarin-pkg-msbuild/mono/create_bootstrap.sh
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ # This creates a bootstrap from an exising mono installation
+ # This is just to ensure that we have the correct "matched" Roslyn
+Index: xamarin-pkg-msbuild/msbuild-deploy.in
+===================================================================
+--- xamarin-pkg-msbuild.orig/msbuild-deploy.in
++++ xamarin-pkg-msbuild/msbuild-deploy.in
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ ABSOLUTE_PATH=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)/`basename "${BASH_SOURCE[0]}"`
+ MSBUILD_SRC_DIR=`dirname $ABSOLUTE_PATH`
+ mono $MONO_OPTIONS $MSBUILD_SRC_DIR/MSBuild.exe $*
+Index: xamarin-pkg-msbuild/eng/cibuild_bootstrapped_msbuild.sh
+===================================================================
+--- xamarin-pkg-msbuild.orig/eng/cibuild_bootstrapped_msbuild.sh
++++ xamarin-pkg-msbuild/eng/cibuild_bootstrapped_msbuild.sh
+@@ -56,6 +56,7 @@ function DownloadMSBuildForMono {
+     unzip -q "$msbuild_zip" -d "$artifacts_dir"
+     # rename just to make it obvious when reading logs!
+     mv $artifacts_dir/msbuild $mono_msbuild_dir
++    sed -i 's#/sh$#/bash#' $artifacts_dir/mono-msbuild/msbuild
+     chmod +x $artifacts_dir/mono-msbuild/MSBuild.dll
+     rm "$msbuild_zip"
+   fi

--- a/recipes-mono/msbuild/msbuild/mono-msbuild-use-more-bash.patch
+++ b/recipes-mono/msbuild/msbuild/mono-msbuild-use-more-bash.patch
@@ -1,0 +1,28 @@
+diff --git a/mono/build/extract_and_copy_hostfxr.sh b/mono/build/extract_and_copy_hostfxr.sh
+index 68a8586..8fae00b 100755
+--- a/mono/build/extract_and_copy_hostfxr.sh
++++ b/mono/build/extract_and_copy_hostfxr.sh
+@@ -21,7 +21,8 @@ OLDCWD=`pwd`
+ cd $TMPDIR
+ 
+ GetDotNetInstallScript $TMPDIR
+-sh ./dotnet-install.sh --version $1 --install-dir $DOTNET_DIR --architecture x64 --runtime dotnet --skip-non-versioned-files
++chmod +x dotnet-install.sh
++./dotnet-install.sh --version $1 --install-dir $DOTNET_DIR --architecture x64 --runtime dotnet --skip-non-versioned-files
+ find $DOTNET_DIR -name libhostfxr.dylib | xargs -I {} cp -v {} $DESTDIR
+ 
+ cd $OLDCWD
+diff --git a/mono/build/get_sdk_files.sh b/mono/build/get_sdk_files.sh
+index 11d2ffc..fbf52e2 100755
+--- a/mono/build/get_sdk_files.sh
++++ b/mono/build/get_sdk_files.sh
+@@ -24,7 +24,8 @@ OLDCWD=`pwd`
+ cd $TMPDIR
+ 
+ GetDotNetInstallScript $TMPDIR
+-sh ./dotnet-install.sh --version $dotnet_sdk_version --install-dir $DOTNET_DIR --architecture x64 --skip-non-versioned-files
++chmod +x dotnet-install.sh
++./dotnet-install.sh --version $dotnet_sdk_version --install-dir $DOTNET_DIR --architecture x64 --skip-non-versioned-files
+ find $DOTNET_DIR -name Microsoft.NETCoreSdk.BundledVersions.props -exec cp -v {} $1 \;
+ find $DOTNET_DIR -name RuntimeIdentifierGraph.json -exec cp -v {} $1 \;
+ 

--- a/recipes-mono/msbuild/msbuild_16.6.bb
+++ b/recipes-mono/msbuild/msbuild_16.6.bb
@@ -1,0 +1,56 @@
+SUMMARY = "The Microsoft Build Engine is a platform for building applications."
+HOMEPAGE = "https://docs.microsoft.com/visualstudio/msbuild/msbuild"
+SECTION = "console/apps"
+LICENSE = "MIT"
+
+DEPENDS = "unzip-native dotnet"
+
+RDEPENDS_${PN} = "dotnet"
+
+LIC_FILES_CHKSUM = "file://license;md5=aa2bb45abfacf721bd09860b11b79f5a \
+                    file://ref/LicenseHeader.txt;md5=b06c0743af93aeb14a577bb2bfdada8e"
+
+inherit mono
+
+SRCREV = "94d0c55bc96f297618d50cc32167ddba9fee30b0"
+
+SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git \
+           file://mono-msbuild-dotnetbits-case.patch \
+           file://mono-msbuild-license-case.patch \
+           file://mono-msbuild-no-hostfxr.patch \
+           file://mono-msbuild-use-bash.patch \
+           file://0001-Don-t-try-to-run-pkill.patch \
+           file://0001-Copy-hostfxr.patch \
+           "
+
+S = "${WORKDIR}/git"
+
+do_configure () {
+    sed "s|%libhostfxr%|${STAGING_DIR_TARGET}${libdir}/libhostfxr.so|g" -i ${S}/eng/cibuild_bootstrapped_msbuild.sh
+
+    sed "s|\$(HOME)\\\.nuget\\\packages|${NUGET_PACKAGES}|g" -i ${S}/mono/build/common.props
+    sed "s|\$(MonoInstallPrefix)\\\lib|${D}${libdir}|g" -i ${S}/mono/build/install.proj
+    sed "s|\$(MonoInstallPrefix)\\\bin|${D}${bindir}|g" -i ${S}/mono/build/install.proj
+    sed "s|\$(MonoInstallPrefix)\\\share|${D}${datadir}|g" -i ${S}/mono/build/install.proj
+
+    sed "s|'\$1'/bin|${bindir}|g" -i ${S}/mono/build/gen_msbuild_wrapper.sh
+    sed "s|\$1/lib|${libdir}|g" -i ${S}/mono/build/gen_msbuild_wrapper.sh
+}
+
+export DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR="${STAGING_DATADIR_NATIVE}/dotnet"
+export CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt"
+
+do_compile () {
+    ./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests /p:DisableNerdbankVersioning=true
+}
+
+do_install () {
+    ./stage1/mono-msbuild/msbuild mono/build/install.proj /p:MonoInstallPrefix="${D}" /p:Configuration=Release-MONO /p:IgnoreDiffFailure=true
+}
+
+FILES_${PN} = "\
+    ${bindir} \
+    ${libdir}/mono \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-mono/msbuild/msbuild_16.6.bb
+++ b/recipes-mono/msbuild/msbuild_16.6.bb
@@ -21,6 +21,7 @@ SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git \
            file://mono-msbuild-use-bash.patch \
            file://0001-Don-t-try-to-run-pkill.patch \
            file://0001-Copy-hostfxr.patch \
+           file://0002-Remove-myget-feeds-and-replace-with-AzDO-feeds.patch \
            "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
The current msbuild 15.4 recipe is broken. This pull request adds a new recipe for version 16.6. I was only able to test the msbuild-native recipe with mono 6.8.0.105 and poky zeus, every other configuration is completely untested.

I added a recipe for dotnet as it is a dependency of msbuild. I copied it from [intel-iot-devkit/meta-iot-cloud](https://github.com/intel-iot-devkit/meta-iot-cloud) as I didn't want to depend on the whole layer just for a single recipe. The layer is MIT licensed, this probably needs attribution.

There is also a change to use correct paths in the config for mono-native, I think this should not break other things.

It would be nice if someone can test this a bit more and give feedback.

Fixes #38.