### PR TITLE
conf/layer.conf: Re-enable Sumo support

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -22,4 +22,4 @@ PREFERRED_VERSION_nuget-native ?= "5.2.0"
 PREFERRED_VERSION_msbuild ?= "16.6"
 PREFERRED_VERSION_msbuild-native ?= "16.6"
 
-LAYERSERIES_COMPAT_mono = "thud warrior zeus dunfell gatesgarth"
+LAYERSERIES_COMPAT_mono = "sumo thud warrior zeus dunfell gatesgarth"


### PR DESCRIPTION
The original reason for removing Yocto 2.5 Sumo support was its EOL state. But there's nothing in meta-mono that makes it
inherently incompatible with Sumo.