### PR TITLE
libgdiplus: Don't use --with-x11 for 6.x versions

### DIFF
--- a/recipes-mono/libgdiplus/libgdiplus-6.xx.inc
+++ b/recipes-mono/libgdiplus/libgdiplus-6.xx.inc
@@ -4,7 +4,7 @@ PACKAGECONFIG[tiff] = "--with-libtiff,--without-libtiff,tiff"
 PACKAGECONFIG[gif] = "--with-libgif,--without-libgif,giflib"
 PACKAGECONFIG[exif] = "--with-libexif,--without-libexif,libexif"
 PACKAGECONFIG[pango] = "--with-pango,--without-pango,pango"
-PACKAGECONFIG[x11] = "--with-x11,--without-x11,virtual/libx11 libxft"
+PACKAGECONFIG[x11] = ",--without-x11,virtual/libx11 libxft"
 
 DEPENDS =+ "cairo freetype fontconfig libpng"
 


### PR DESCRIPTION
configure.ac in libgdiplus disables detecting X11 when either
option --with-x11 or --without-x11 is present.
Don't use --with-x11 to allow detecting X11.

Signed-off-by: Zoltán Böszörményi <zboszor@pr.hu>