### PR TITLE
Add test-image-mono to use for Jenkins CI builds (#62)

### DIFF
--- a/recipes-mono/images/test-image-mono.bb
+++ b/recipes-mono/images/test-image-mono.bb
@@ -1,0 +1,10 @@
+require recipes-sato/images/core-image-sato.bb
+
+require core-image-mono.inc
+
+# Build up meta-mono test image here
+IMAGE_INSTALL += "msbuild \
+"
+
+IMAGE_BASENAME = "${PN}"
+


### PR DESCRIPTION
This will be built against any PRs before allowing merge

Currently based on core-image-mono and adding

- msbuild

Signed-off-by: Alex J Lennon <ajlennon@dynamicdevices.co.uk>