### PR TITLE
msbuild: Reduce dotnet dependency to libhostfxr

### DIFF
--- a/recipes-mono/dotnet/dotnet_3.1.11.bb
+++ b/recipes-mono/dotnet/dotnet_3.1.11.bb
@@ -67,7 +67,6 @@ shell_do_install() {
 
     # Symlinks
     ln -s ${D}${datadir}/dotnet/dotnet ${D}${bindir}/dotnet
-    ln -s ${D}${datadir}/dotnet/host/fxr/${HOST_FXR}/libhostfxr.so ${D}${libdir}/libhostfxr.so
 }
 
 FILES_${PN} = "\

--- a/recipes-mono/msbuild/msbuild-libhostfxr/0001-Don-t-set-a-plethora-of-compiler-arguments-through-c.patch
+++ b/recipes-mono/msbuild/msbuild-libhostfxr/0001-Don-t-set-a-plethora-of-compiler-arguments-through-c.patch
@@ -1,0 +1,67 @@
+From 26baea13627ddf3c97ce528ab1b6559d8cfb82c7 Mon Sep 17 00:00:00 2001
+From: Nicolas Jeker <n.jeker@gmx.net>
+Date: Mon, 8 Feb 2021 11:48:17 +0100
+Subject: [PATCH] Don't set a plethora of compiler arguments through cmake
+
+---
+ src/corehost/cli/common.cmake |  3 ---
+ src/settings.cmake            | 22 ----------------------
+ 2 files changed, 25 deletions(-)
+
+diff --git a/src/corehost/cli/common.cmake b/src/corehost/cli/common.cmake
+index 7469fd16..3abe5e57 100644
+--- a/src/corehost/cli/common.cmake
++++ b/src/corehost/cli/common.cmake
+@@ -8,9 +8,6 @@ if(WIN32)
+     add_compile_options($<$<CONFIG:RelWithDebInfo>:/MT>)
+     add_compile_options($<$<CONFIG:Release>:/MT>)
+     add_compile_options($<$<CONFIG:Debug>:/MTd>)
+-else()
+-    add_compile_options(-fPIC)
+-    add_compile_options(-fvisibility=hidden)
+ endif()
+ 
+ include(${CMAKE_CURRENT_LIST_DIR}/setup.cmake)
+diff --git a/src/settings.cmake b/src/settings.cmake
+index 29d57b44..0d524aa6 100644
+--- a/src/settings.cmake
++++ b/src/settings.cmake
+@@ -189,27 +189,6 @@ if(WIN32)
+     set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} /DEBUG /OPT:REF /OPT:ICF")
+     set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
+     set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
+-else()
+-    add_compile_options(-g) # enable debugging information
+-    add_compile_options(-Wall)
+-    add_compile_options(-Wextra)
+-    if(CMAKE_C_COMPILER_ID STREQUAL Clang)
+-        # Uncomment to enable additional, but likely irrelvant, warnings. For
+-        # example, this will warn about using c++11 features even when
+-        # compiling with -std=c++11.
+-        # add_compile_options(-Weverything)
+-    endif()
+-    add_compile_options(-Werror)
+-    add_compile_options(-Wno-missing-field-initializers)
+-    add_compile_options(-Wno-unused-function)
+-    add_compile_options(-Wno-unused-local-typedef)
+-    add_compile_options(-Wno-unused-macros)
+-    add_compile_options(-Wno-unused-parameter)
+-endif()
+-
+-# Older CMake doesn't support CMAKE_CXX_STANDARD and GCC/Clang need a switch to enable C++ 11
+-if(${CMAKE_CXX_COMPILER_ID} MATCHES "(Clang|GNU)")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+ endif()
+ 
+ # This is required to map a symbol reference to a matching definition local to the module (.so)
+@@ -218,7 +197,6 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic -Bsymbolic-functions")
+     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--build-id=sha1")
+     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--build-id=sha1")
+-    add_compile_options(-fstack-protector-strong)
+ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+     add_compile_options(-fstack-protector)
+ elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+-- 
+2.30.0
+

--- a/recipes-mono/msbuild/msbuild-libhostfxr_3.1.11.bb
+++ b/recipes-mono/msbuild/msbuild-libhostfxr_3.1.11.bb
@@ -1,0 +1,60 @@
+SUMMARY = "Build system for .NET projects - unmanaged helper library"
+HOMEPAGE = "https://github.com/dotnet/core-setup"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE.TXT;md5=9fc642ff452b28d62ab19b7eea50dfb9"
+
+COMPATIBLE_HOST ?= "(i.86|x86_64|arm|aarch64).*-linux"
+
+SRC_URI = "git://github.com/dotnet/core-setup.git;branch=release/3.1 \
+           file://0001-Don-t-set-a-plethora-of-compiler-arguments-through-c.patch;patchdir=${WORKDIR}/git \
+           "
+SRCREV = "f5eceb810586ea6138aadcef9e2bba115015ab99"
+
+inherit cmake
+
+S = "${WORKDIR}/git/src/corehost"
+
+def get_dotnet_arch(bb, d, arch_var):
+    import re
+    a = d.getVar(arch_var)
+    if   re.match(r'(i.86|athlon|x86.64)$', a):         return 'I386'
+    elif re.match(r'arm$', a):                          return 'ARM'
+    elif re.match(r'armeb$', a):                        return 'ARM'
+    elif re.match(r'aarch64$', a):                      return 'ARM64'
+    elif re.match(r'aarch64_be$', a):                   return 'ARM64'
+    else:
+        raise bb.parse.SkipRecipe("Cannot map '%s' to a supported dotnet architecture" % a)
+
+def get_dotnet_host_arch(bb, d):
+    return get_dotnet_arch(bb, d, 'HOST_ARCH')
+
+def get_dotnet_target_arch(bb, d):
+    return get_dotnet_arch(bb, d, 'TARGET_ARCH')
+
+EXTRA_OECMAKE = " \
+    -DCLI_CMAKE_HOST_VER:STRING=${PV} \
+    -DCLI_CMAKE_COMMON_HOST_VER:STRING=${PV} \
+    -DCLI_CMAKE_HOST_FXR_VER:STRING=${PV} \
+    -DCLI_CMAKE_HOST_POLICY_VER:STRING=${PV} \
+    -DCLI_CMAKE_PKG_RID:STRING=linux \
+    -DCLI_CMAKE_COMMIT_HASH:STRING=${SRCREV} \
+"
+
+EXTRA_OECMAKE_append_class-native = " \
+    -DCLI_CMAKE_PLATFORM_ARCH_${@get_dotnet_host_arch(bb, d)}=1 \
+"
+
+EXTRA_OECMAKE_append_class-target = " \
+    -DCLI_CMAKE_PLATFORM_ARCH_${@get_dotnet_target_arch(bb, d)}=1 \
+"
+
+do_install() {
+	install -d ${D}${libdir}/mono/msbuild/Current/bin/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver
+	install -m755 ${B}/cli/fxr/libhostfxr.so ${D}${libdir}/mono/msbuild/Current/bin/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver/libhostfxr.so
+}
+
+FILES_${PN} = " \
+    ${libdir}/mono/msbuild/Current/bin/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver/libhostfxr.so \
+"
+
+BBCLASSEXTEND = "native"

--- a/recipes-mono/msbuild/msbuild_16.6.bb
+++ b/recipes-mono/msbuild/msbuild_16.6.bb
@@ -3,9 +3,9 @@ HOMEPAGE = "https://docs.microsoft.com/visualstudio/msbuild/msbuild"
 SECTION = "console/apps"
 LICENSE = "MIT"
 
-DEPENDS = "unzip-native dotnet"
+DEPENDS = "unzip-native msbuild-libhostfxr-native"
 
-RDEPENDS_${PN} = "dotnet"
+RDEPENDS_${PN} = "msbuild-libhostfxr"
 
 LIC_FILES_CHKSUM = "file://license;md5=aa2bb45abfacf721bd09860b11b79f5a \
                     file://ref/LicenseHeader.txt;md5=b06c0743af93aeb14a577bb2bfdada8e"
@@ -26,8 +26,11 @@ SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git \
 
 S = "${WORKDIR}/git"
 
+LIBHOSTFXR_PATH = "${libdir}/mono/msbuild/Current/bin/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver/libhostfxr.so"
+LIBHOSTFXR_PATH_prepend_class-target = "${STAGING_DIR_NATIVE}"
+
 do_configure () {
-    sed "s|%libhostfxr%|${STAGING_DIR_TARGET}${libdir}/libhostfxr.so|g" -i ${S}/eng/cibuild_bootstrapped_msbuild.sh
+    sed "s|%libhostfxr%|${LIBHOSTFXR_PATH}|g" -i ${S}/eng/cibuild_bootstrapped_msbuild.sh
 
     sed "s|\$(HOME)\\\.nuget\\\packages|${NUGET_PACKAGES}|g" -i ${S}/mono/build/common.props
     sed "s|\$(MonoInstallPrefix)\\\lib|${D}${libdir}|g" -i ${S}/mono/build/install.proj


### PR DESCRIPTION
Fixes compatibility with x86 build hosts by building the library from
source and removes the dependency on the full dotnet package.

I would like to thank openSUSE for their excellent [msbuild-libhostfxr](https://build.opensuse.org/package/view_file/Mono:Factory/msbuild-libhostfxr/msbuild-libhostfxr.spec) package that put me on the right track.

Building for x86 is currently untested, if somebody has an x86 machine to test with, please do so and report back.

Fixes #64