### PR TITLE
msbuild-libhostfxr: Patch broken objcopy detection

### DIFF
--- a/recipes-mono/msbuild/msbuild-libhostfxr/0002-Remove-broken-objcopy-detection-STRIP_SYMBOLS-is-uns.patch
+++ b/recipes-mono/msbuild/msbuild-libhostfxr/0002-Remove-broken-objcopy-detection-STRIP_SYMBOLS-is-uns.patch
@@ -1,0 +1,38 @@
+From f45574b7751d668ec8c5d7c87938bb17a2b08a0f Mon Sep 17 00:00:00 2001
+From: Nicolas Jeker <n.jeker@gmx.net>
+Date: Wed, 10 Feb 2021 08:13:55 +0100
+Subject: [PATCH] Remove broken objcopy detection, STRIP_SYMBOLS is unset
+ anyway
+
+---
+ src/settings.cmake | 14 --------------
+ 1 file changed, 14 deletions(-)
+
+diff --git a/src/settings.cmake b/src/settings.cmake
+index 0d524aa6..2bd0f8b7 100644
+--- a/src/settings.cmake
++++ b/src/settings.cmake
+@@ -52,20 +52,6 @@ if (NOT WIN32)
+         if (STRIP STREQUAL "STRIP-NOTFOUND")
+             message(FATAL_ERROR "strip not found")
+         endif()
+-    else (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+-        # Ensure that objcopy is present
+-        if(DEFINED ENV{ROOTFS_DIR})
+-            if(CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l OR CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
+-                find_program(OBJCOPY ${TOOLCHAIN}-objcopy)
+-            else()
+-                message(FATAL_ERROR "Only AMD64, X86, ARM64 and ARM are supported")
+-            endif()
+-        else()
+-            find_program(OBJCOPY objcopy)
+-        endif()
+-        if (OBJCOPY STREQUAL "OBJCOPY-NOTFOUND" AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
+-            message(FATAL_ERROR "objcopy not found")
+-        endif()
+     endif (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+ endif ()
+ 
+-- 
+2.30.1
+

--- a/recipes-mono/msbuild/msbuild-libhostfxr_3.1.11.bb
+++ b/recipes-mono/msbuild/msbuild-libhostfxr_3.1.11.bb
@@ -7,6 +7,7 @@ COMPATIBLE_HOST ?= "(i.86|x86_64|arm|aarch64).*-linux"
 
 SRC_URI = "git://github.com/dotnet/core-setup.git;branch=release/3.1 \
            file://0001-Don-t-set-a-plethora-of-compiler-arguments-through-c.patch;patchdir=${WORKDIR}/git \
+           file://0002-Remove-broken-objcopy-detection-STRIP_SYMBOLS-is-uns.patch;patchdir=${WORKDIR}/git \
            "
 SRCREV = "f5eceb810586ea6138aadcef9e2bba115015ab99"
 


### PR DESCRIPTION
This is completely unnecessary since we don't set STRIP_SYMBOLS, so
objcopy is never used. The debug symbols are split later by bitbake.

This should fix the `objcopy not found` error in #65