### PR TITLE
msbuild-libhostfxr: Install libhostxfr.so into libdir in native mode

### DIFF
--- a/recipes-mono/msbuild/msbuild-libhostfxr_3.1.11.bb
+++ b/recipes-mono/msbuild/msbuild-libhostfxr_3.1.11.bb
@@ -53,6 +53,10 @@ do_install() {
 	install -m755 ${B}/cli/fxr/libhostfxr.so ${D}${libdir}/mono/msbuild/Current/bin/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver/libhostfxr.so
 }
 
+do_install_append_class-native () {
+	install -m755 ${B}/cli/fxr/libhostfxr.so ${D}${libdir}
+}
+
 FILES_${PN} = " \
     ${libdir}/mono/msbuild/Current/bin/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver/libhostfxr.so \
 "


### PR DESCRIPTION
Fixes #69 

Signed-off-by: Zoltán Böszörményi <zboszor@pr.hu>
