### PR TITLE
mono: RPROVIDES needs to be package specific

### DIFF
--- a/recipes-mono/mono/mono-native-6.xx-base.inc
+++ b/recipes-mono/mono/mono-native-6.xx-base.inc
@@ -3,7 +3,7 @@ PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)}
 
 inherit native
 
-RPROVIDES += "nativesdk-mono"
+RPROVIDES_${PN} += "nativesdk-mono"
 PROVIDES += "nativesdk-mono"
 
 do_compile() {


### PR DESCRIPTION
Signed-off-by: Zoltán Böszörményi <zboszor@pr.hu>

Fixes: #79 