### PR TITLE
msbuild: Match branch name to upstream

### DIFF
--- a/recipes-mono/msbuild/msbuild_16.6.bb
+++ b/recipes-mono/msbuild/msbuild_16.6.bb
@@ -14,7 +14,7 @@ inherit mono
 
 SRCREV = "94d0c55bc96f297618d50cc32167ddba9fee30b0"
 
-SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git \
+SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git;branch=main \
            file://mono-msbuild-dotnetbits-case.patch \
            file://mono-msbuild-license-case.patch \
            file://mono-msbuild-no-hostfxr.patch \


### PR DESCRIPTION
The upstream linux-packaging-msbuild repository changed their branch
name from master to main, so we need to explicitly specify it in SRC_URI
as bitbake uses master by default.