### PR TITLE
mono: fix removing x86 binaries

### DIFF
--- a/recipes-mono/mono/mono-5.16.inc
+++ b/recipes-mono/mono/mono-5.16.inc
@@ -1,4 +1,16 @@
+# The source package erroneously contains some build output files from a
+# build for x86. These need to be deleted else we can't cross-compile the
+# package.
+#
+# Clenaup is based on mono commit ffa8c9992f8 ("Merge pull request #11509 from
+# directhex/cleanup-system-native-make-dist")
 
-do_configure_append () {
-	rm -rf ${S}/external/corefx/src/Native/Unix/System.Native/{.libs/*,*.{o,lo}}
+do_configure_prepend () {
+    rm -rf $(find ${S} -type d -name "*\.libs")
+    rm -rf $(find ${S} -name "*\.deps")
+    rm -f $(find ${S} -name "*\.o")
+    rm -f $(find ${S} -name "*\.so")
+    rm -f $(find ${S} -name "*\.lo")
+    rm -f $(find ${S} -name "*\.Plo")
+    rm -f $(find ${S} -name "\.dirstamp")
 }


### PR DESCRIPTION
Note this should be backported to all supported versions.