### PR TITLE
classes/mono.bbclass: Fix ignored RDEPENDS:${PN} += "..."

### DIFF
--- a/classes/mono.bbclass
+++ b/classes/mono.bbclass
@@ -1,10 +1,10 @@
 # Class for building C# packages. If your package is all-managed, add
 # PACKAGE_ARCH="all"
 
-DEPENDS += "mono-native ca-certificates-native mono"
-RDEPENDS:${PN} += "mono"
+DEPENDS:append = " mono-native ca-certificates-native mono"
+RDEPENDS:${PN}:append = " mono"
 
-FILES:${PN} += "\
+FILES:${PN}:append = " \
   ${libdir}/mono/*/*.exe \
   ${libdir}/mono/*/*.dll \
   ${libdir}/mono/*/*.config \
@@ -12,12 +12,12 @@ FILES:${PN} += "\
   ${libdir}/mono/gac/*/*/*.*.config \
 "
 
-FILES:${PN}-dbg += "\
+FILES:${PN}-dbg:append = " \
   ${libdir}/mono/*/*.mdb \
   ${libdir}/mono/gac/*/*/*.mdb \
 "
 
-FILES:${PN}-dev += "\
+FILES:${PN}-dev:append = " \
   ${libdir}/mono/*/*.rsp \
   ${libdir}/mono/*/*.xml \
   ${libdir}/mono/gac/*/*/*.xml \
@@ -27,7 +27,7 @@ FILES:${PN}-dev += "\
   ${libdir}/mono/*/*.Targets \
 "
 
-FILES:${PN}-doc += "\
+FILES:${PN}-doc:append = " \
   ${libdir}/monodoc/* \
 "
 


### PR DESCRIPTION
If a recipe uses "inherit mono" and later writes RDEPENDS:${PN} = "..."
then RDEPENDS:${PN} += "..." in mono.bbclass will not take effect.
It's documented somewhere in the Yocto manual.

Use the override :append syntax for other variables, too, not
just RDEPENDS.

Signed-off-by: Zoltán Böszörményi <zboszor@gmail.com>