### PR TITLE
nuget: Set BB_CHECK_SSL_CERTS=0

### DIFF
--- a/recipes-mono/nuget/nuget.inc
+++ b/recipes-mono/nuget/nuget.inc
@@ -6,6 +6,9 @@ HOMEPAGE = "http://nuget.org/"
 # This package ships Mono EXE and a shell script
 PACKAGE_ARCH="all"
 
+# Fully updated Fedora 33 and 34 say that dist.nuget.org cert is untrusted
+BB_CHECK_SSL_CERTS = "0"
+
 inherit mono
 
 SRC_URI = " \


### PR DESCRIPTION
Maybe Microsoft didn't renew their certificate but downloading
nuget.exe fails because the cert is untrusted now.

This should only be a temporary measure.

Signed-off-by: Zoltán Böszörményi <zboszor@gmail.com>