### PR TITLE
Fix mono 6.12.0.147 and add 6.12.0.154

### DIFF
--- a/recipes-mono/mono/mono-6.12.0.147.inc
+++ b/recipes-mono/mono/mono-6.12.0.147.inc
@@ -1,5 +1,10 @@
+BASEPV = "6.12.0.122"
 SRC_URI[sha256sum] = "29c277660fc5e7513107aee1cbf8c5057c9370a4cdfeda2fc781be6986d89d23"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${WORKDIR}/mono-${BASEPV}"
 
 DEPENDS += " cmake-native"
+
+do_configure:prepend () {
+	sed -i 's/${BASEPV}/${PV}/g' configure.ac
+}

--- a/recipes-mono/mono/mono-6.12.0.147/0004-Disable-DebuggerTests.Crash-since-it-fails-on-Linux-.patch
+++ b/recipes-mono/mono/mono-6.12.0.147/0004-Disable-DebuggerTests.Crash-since-it-fails-on-Linux-.patch
@@ -1,0 +1,28 @@
+From fdf57e77442b94c38ac1d4f33e8be752351a8db5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexander=20K=C3=B6plinger?= <alex.koeplinger@outlook.com>
+Date: Mon, 8 Mar 2021 11:45:16 +0100
+Subject: [PATCH 04/32] Disable DebuggerTests.Crash since it fails on Linux
+ i386 in CI
+
+See https://github.com/mono/mono/issues/20905
+
+(cherry picked from commit 7eb63051a8b49d9174dd65a319b6b08f98385ad9)
+---
+ mcs/class/Mono.Debugger.Soft/Test/dtest.cs | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+index 8c953f6fe3d..0fbe87421db 100644
+--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
++++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+@@ -2475,6 +2475,7 @@ Event step_out_await (string method, Event e)
+ 	[Test]
+ 	[Category("NotOnWindows")]
+ 	[Category ("AndroidSdksNotWorking")]
++	[Ignore("https://github.com/mono/mono/issues/20905")] // fails on Linux i386 on CI
+ 	public void Crash () {
+ 		string [] existingCrashFileEntries = Directory.GetFiles (".", "mono_crash*.json");
+ 
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.147/0007-Don-t-include-mono-dtrace.h-when-generating-offsets.patch
+++ b/recipes-mono/mono/mono-6.12.0.147/0007-Don-t-include-mono-dtrace.h-when-generating-offsets.patch
@@ -1,0 +1,26 @@
+From be9218f4d1f7529fbe85d15c58f6fe78161909b3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexander=20K=C3=B6plinger?= <alex.koeplinger@outlook.com>
+Date: Wed, 10 Mar 2021 22:36:56 +0100
+Subject: [PATCH 07/32] Don't include mono-dtrace.h when generating offsets
+
+offsets-tool can run before mono-dtrace.h is generated which leads to a compiler error about the file missing.
+---
+ mono/utils/dtrace.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mono/utils/dtrace.h b/mono/utils/dtrace.h
+index 540f2588a8b..bd3062530ff 100644
+--- a/mono/utils/dtrace.h
++++ b/mono/utils/dtrace.h
+@@ -10,7 +10,7 @@
+ #ifndef __UTILS_DTRACE_H__
+ #define __UTILS_DTRACE_H__
+ 
+-#ifdef ENABLE_DTRACE
++#if defined(ENABLE_DTRACE) && !defined(MONO_GENERATING_OFFSETS)
+ 
+ #include <mono/utils/mono-dtrace.h>
+ 
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.147/0008-2020-02-marshal-Fix-VARIANT-and-BSTR-marshaling-in-s.patch
+++ b/recipes-mono/mono/mono-6.12.0.147/0008-2020-02-marshal-Fix-VARIANT-and-BSTR-marshaling-in-s.patch
@@ -1,0 +1,251 @@
+From acb8d8ed6fd7fc7034b57157db1119bb5e259cc3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Aleksey=20Kliger=20=28=CE=BBgeek=29?= <alklig@microsoft.com>
+Date: Thu, 11 Mar 2021 12:38:52 -0500
+Subject: [PATCH 08/32] [2020-02][marshal] Fix VARIANT and BSTR marshaling in
+ structs (#20918)
+
+* [tests] Add BStr and VARIANT in structs interop tests
+
+* [marshal] Fix reverse P/Invoke marshaling VARIANT fields
+
+Partial revert of https://github.com/mono/mono/pull/8732
+
+If a managed struct is declared as
+
+        public struct StructWithVariant
+        {
+            [MarshalAs (UnmanagedType.Struct)]
+            public object data;
+        };
+
+Then the `data` field should be marshalled as a VARIANT.
+
+The fix checks that the field's type is `object` and uses VARIANT for
+marshaling, otherwise it continues as in mono/mono#8732 and uses
+MONO_MARSHAL_CONV_OBJECT_STRUCT
+
+* [marshal] Marshal BSTR from reverse pinvokes
+---
+ mono/metadata/marshal-ilgen.c |  8 ++++-
+ mono/metadata/metadata.c      | 12 ++++++-
+ mono/tests/cominterop.cs      | 65 +++++++++++++++++++++++++++++++++--
+ mono/tests/libtest.c          | 48 ++++++++++++++++++++++++++
+ 4 files changed, 129 insertions(+), 4 deletions(-)
+
+diff --git a/mono/metadata/marshal-ilgen.c b/mono/metadata/marshal-ilgen.c
+index 5472727ef0f..de6fefed06e 100644
+--- a/mono/metadata/marshal-ilgen.c
++++ b/mono/metadata/marshal-ilgen.c
+@@ -488,6 +488,13 @@ emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv
+ 		mono_mb_emit_icall (mb, ves_icall_mono_string_from_utf16);
+ 		mono_mb_emit_byte (mb, CEE_STIND_REF);
+ 		break;
++	case MONO_MARSHAL_CONV_STR_BSTR:
++		mono_mb_emit_ldloc (mb, 1);
++		mono_mb_emit_ldloc (mb, 0);
++		mono_mb_emit_byte (mb, CEE_LDIND_I);
++		mono_mb_emit_icall (mb, mono_string_from_bstr_icall);
++		mono_mb_emit_byte (mb, CEE_STIND_REF);
++		break;
+ 	case MONO_MARSHAL_CONV_OBJECT_STRUCT: {
+ 		MonoClass *klass = mono_class_from_mono_type_internal (type);
+ 		int src_var, dst_var;
+@@ -576,7 +583,6 @@ emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv
+ 		break;
+ 	}
+ 		
+-	case MONO_MARSHAL_CONV_STR_BSTR:
+ 	case MONO_MARSHAL_CONV_STR_ANSIBSTR:
+ 	case MONO_MARSHAL_CONV_STR_TBSTR:
+ 	case MONO_MARSHAL_CONV_ARRAY_SAVEARRAY:
+diff --git a/mono/metadata/metadata.c b/mono/metadata/metadata.c
+index 5f6568da9b0..b2987016ef2 100644
+--- a/mono/metadata/metadata.c
++++ b/mono/metadata/metadata.c
+@@ -6781,7 +6781,17 @@ handle_enum:
+ 		if (mspec) {
+ 			switch (mspec->native) {
+ 			case MONO_NATIVE_STRUCT:
+-				*conv = MONO_MARSHAL_CONV_OBJECT_STRUCT;
++				// [MarshalAs(UnmanagedType.Struct)]
++				// object field;
++				//
++				// becomes a VARIANT
++				//
++				// [MarshalAs(UnmangedType.Struct)]
++				// SomeClass field;
++				//
++				// becomes uses the CONV_OBJECT_STRUCT conversion
++				if (t != MONO_TYPE_OBJECT)
++					*conv = MONO_MARSHAL_CONV_OBJECT_STRUCT;
+ 				return MONO_NATIVE_STRUCT;
+ 			case MONO_NATIVE_CUSTOM:
+ 				return MONO_NATIVE_CUSTOM;
+diff --git a/mono/tests/cominterop.cs b/mono/tests/cominterop.cs
+index e83cafd0625..11cb68bcdbc 100644
+--- a/mono/tests/cominterop.cs
++++ b/mono/tests/cominterop.cs
+@@ -224,7 +224,21 @@ public class Tests
+ 	[DllImport ("libtest")]
+ 	public static extern int mono_test_marshal_variant_out_bool_false_unmanaged (VarRefFunc func);
+ 
+-    [DllImport ("libtest")]
++	public delegate int CheckStructWithVariantFunc ([MarshalAs (UnmanagedType.Struct)] StructWithVariant obj);
++	[DllImport ("libtest")]
++	public static extern int mono_test_marshal_struct_with_variant_in_unmanaged (CheckStructWithVariantFunc func);
++
++	public delegate int CheckStructWithBstrFunc ([MarshalAs (UnmanagedType.Struct)] StructWithBstr obj);
++	[DllImport ("libtest")]
++	public static extern int mono_test_marshal_struct_with_bstr_in_unmanaged (CheckStructWithBstrFunc func);
++
++	[DllImport ("libtest")]
++	public static extern int mono_test_marshal_struct_with_variant_out_unmanaged ([MarshalAs (UnmanagedType.Struct)] StructWithVariant obj);
++
++	[DllImport ("libtest")]
++	public static extern int mono_test_marshal_struct_with_bstr_out_unmanaged ([MarshalAs (UnmanagedType.Struct)] StructWithBstr obj);
++
++	[DllImport ("libtest")]
+ 	public static extern int mono_test_marshal_com_object_create (out IntPtr pUnk);
+ 
+ 	[DllImport ("libtest")]
+@@ -338,7 +352,6 @@ public class Tests
+ 
+ 	public static int Main ()
+ 	{
+-
+ 		bool isWindows = !(((int)Environment.OSVersion.Platform == 4) ||
+ 			((int)Environment.OSVersion.Platform == 128));
+ 
+@@ -356,6 +369,15 @@ public static int Main ()
+ 			if (mono_test_marshal_bstr_out_null (out str) != 0 || str != null)
+ 				return 2;
+ 
++			var sbfunc = new CheckStructWithBstrFunc(mono_test_marshal_struct_with_bstr_callback);
++			if (mono_test_marshal_struct_with_bstr_in_unmanaged(sbfunc) != 0)
++				return 3;
++
++			StructWithBstr swithB;
++			swithB.data = "this is a test string";
++			if (mono_test_marshal_struct_with_bstr_out_unmanaged (swithB) != 0)
++				return 4;
++
+ 			#endregion // BSTR Tests
+ 
+ 			#region VARIANT Tests
+@@ -481,6 +503,15 @@ public static int Main ()
+ 			if (mono_test_marshal_variant_out_bstr_byref (out obj) != 0 || (string)obj != "PI")
+ 				return 107;
+ 
++			var svfunc = new CheckStructWithVariantFunc(mono_test_marshal_struct_with_variant_callback);
++			if (mono_test_marshal_struct_with_variant_in_unmanaged(svfunc) != 0)
++				return 108;
++
++			StructWithVariant swithV;
++			swithV.data = (object)-123;
++			if (mono_test_marshal_struct_with_variant_out_unmanaged (swithV) != 0)
++				return 109;
++
+ 			#endregion // VARIANT Tests
+ 
+ 			#region Runtime Callable Wrapper Tests
+@@ -1581,8 +1612,38 @@ public static int TestITestDelegate (ITest itest)
+ 	public static int TestIfaceNoIcall (ITestPresSig itest) {
+ 		return itest.Return22NoICall () == 22 ? 0 : 1;
+ 	}
++
++        public static int mono_test_marshal_struct_with_variant_callback(StructWithVariant sv)
++        {
++            if (sv.data.GetType() != typeof(int))
++                return 1;
++            if ((int)sv.data != -123)
++                return 2;
++            return 0;
++        }
++
++        public static int mono_test_marshal_struct_with_bstr_callback(StructWithBstr sb)
++        {
++            if (sb.data.GetType() != typeof(string))
++                return 1;
++            if ((string)sb.data != "this is a test string")
++                return 2;
++            return 0;
++        }
+ }
+ 
+ public class TestVisible
+ {
+ }
++
++public struct StructWithVariant
++{
++	[MarshalAs (UnmanagedType.Struct)]
++	public object data;
++}
++
++public struct StructWithBstr
++{
++	[MarshalAs (UnmanagedType.BStr)]
++	public string data;
++}
+diff --git a/mono/tests/libtest.c b/mono/tests/libtest.c
+index 3f14636bb25..e5e5f2f14d3 100644
+--- a/mono/tests/libtest.c
++++ b/mono/tests/libtest.c
+@@ -3378,6 +3378,54 @@ mono_test_marshal_variant_out_bool_false_unmanaged(VarRefFunc func)
+ 	return 1;
+ }
+ 
++typedef struct _StructWithVariant {
++    VARIANT data;
++} StructWithVariant;
++typedef int (STDCALL *CheckStructWithVariantFunc) (StructWithVariant sv);
++
++LIBTEST_API int STDCALL 
++mono_test_marshal_struct_with_variant_in_unmanaged(CheckStructWithVariantFunc func)
++{
++    StructWithVariant sv;
++    sv.data.vt = VT_I4;
++    sv.data.lVal = -123;
++    return func(sv);
++}
++
++LIBTEST_API int STDCALL
++mono_test_marshal_struct_with_variant_out_unmanaged (StructWithVariant sv)
++{
++	if (sv.data.vt != VT_I4)
++		return 1;
++	if (sv.data.lVal != -123)
++		return 2;
++	return 0;
++}
++
++typedef struct _StructWithBstr {
++    gunichar2* data;
++} StructWithBstr;
++typedef int (STDCALL *CheckStructWithBstrFunc) (StructWithBstr sb);
++
++LIBTEST_API int STDCALL 
++mono_test_marshal_struct_with_bstr_in_unmanaged(CheckStructWithBstrFunc func)
++{
++    StructWithBstr sb;
++    sb.data = marshal_bstr_alloc("this is a test string");
++    return func(sb);
++}
++
++LIBTEST_API int STDCALL
++mono_test_marshal_struct_with_bstr_out_unmanaged (StructWithBstr sb)
++{
++	char *s = g_utf16_to_utf8 (sb.data, g_utf16_len (sb.data), NULL, NULL, NULL);
++	gboolean same = !strcmp (s, "this is a test string");
++	g_free (s);
++	if (!same)
++		return 1;
++	return 0;
++}
++
+ typedef struct MonoComObject MonoComObject;
+ typedef struct MonoDefItfObject MonoDefItfObject;
+ 
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.147/0010-Fix-the-System.String.Replace-throwing-NotImplemente.patch
+++ b/recipes-mono/mono/mono-6.12.0.147/0010-Fix-the-System.String.Replace-throwing-NotImplemente.patch
@@ -1,0 +1,43 @@
+From 69cfb5fa61ab9b78c7c4f76812b8b84f165dc73d Mon Sep 17 00:00:00 2001
+From: Maxim Lipnin <v-maxlip@microsoft.com>
+Date: Sat, 27 Mar 2021 13:39:33 +0300
+Subject: [PATCH 10/32] Fix the System.String.Replace throwing
+ NotImplementedException (#20960) (#20978)
+
+https://github.com/mono/mono/issues/20948
+---
+ mcs/class/corlib/Test/System/StringTest.cs | 4 ++++
+ mcs/class/corlib/corefx/CompareInfo.cs     | 2 +-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/mcs/class/corlib/Test/System/StringTest.cs b/mcs/class/corlib/Test/System/StringTest.cs
+index eabaa07fe12..4407d4a71a7 100644
+--- a/mcs/class/corlib/Test/System/StringTest.cs
++++ b/mcs/class/corlib/Test/System/StringTest.cs
+@@ -3221,6 +3221,10 @@ public void Replace()
+ 
+ 		// Test replacing null characters (bug #67395)
+ 		Assert.AreEqual ("is this ok ?", "is \0 ok ?".Replace ("\0", "this"), "should not strip content after nullchar");
++
++		// System.String.Replace fails with NotImplementedException https://github.com/mono/mono/issues/20948
++		Assert.AreEqual ("Original", s1.Replace("o", "O", StringComparison.CurrentCulture), "Replace(string, string, StringComparison)");
++		Assert.AreEqual ("Original", s1.Replace("o", "O", false, CultureInfo.CurrentCulture), "Replace(string, string, bool, CultureInfo)");
+ 	}
+ 
+ 	[Test]
+diff --git a/mcs/class/corlib/corefx/CompareInfo.cs b/mcs/class/corlib/corefx/CompareInfo.cs
+index b8205f21ac5..08f6aa50355 100644
+--- a/mcs/class/corlib/corefx/CompareInfo.cs
++++ b/mcs/class/corlib/corefx/CompareInfo.cs
+@@ -86,7 +86,7 @@ int LastIndexOfCore (string source, string target, int startIndex, int count, Co
+ 		unsafe int IndexOfCore (string source, string target, int startIndex, int count, CompareOptions options, int* matchLengthPtr)
+ 		{
+ 			if (matchLengthPtr != null)
+-				throw new NotImplementedException ();
++				*matchLengthPtr = target.Length;
+ 
+ 			return internal_index_switch (source, startIndex, count, target, options, true);
+ 		}
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.147/0014-2020-02-Backport-r4-conv-i-fixes-20986.patch
+++ b/recipes-mono/mono/mono-6.12.0.147/0014-2020-02-Backport-r4-conv-i-fixes-20986.patch
@@ -1,0 +1,85 @@
+From 225ba3c8cb1a309513222a513db0b092bdfab2aa Mon Sep 17 00:00:00 2001
+From: Vlad Brezae <brezaevlad@gmail.com>
+Date: Tue, 30 Mar 2021 17:08:00 +0300
+Subject: [PATCH 14/32] [2020-02] Backport r4-conv-i fixes (#20986)
+
+* [mini] Add missing opcodes for r4 to native int conversions
+
+* [interp] Add handling for conv.i from r4
+---
+ mono/mini/cpu-arm.md         | 1 +
+ mono/mini/cpu-arm64.md       | 1 +
+ mono/mini/interp/transform.c | 7 +++++++
+ mono/mini/mini-arm.c         | 1 +
+ mono/mini/mini-arm64.c       | 1 +
+ 5 files changed, 11 insertions(+)
+
+diff --git a/mono/mini/cpu-arm.md b/mono/mini/cpu-arm.md
+index f3b6641d3f5..516bbb3209d 100644
+--- a/mono/mini/cpu-arm.md
++++ b/mono/mini/cpu-arm.md
+@@ -227,6 +227,7 @@ rmove: dest:f src1:f len:4
+ r4_conv_to_i1: dest:i src1:f len:88
+ r4_conv_to_i2: dest:i src1:f len:88
+ r4_conv_to_i4: dest:i src1:f len:88
++r4_conv_to_i: dest:i src1:f len:88
+ r4_conv_to_u1: dest:i src1:f len:88
+ r4_conv_to_u2: dest:i src1:f len:88
+ r4_conv_to_u4: dest:i src1:f len:88
+diff --git a/mono/mini/cpu-arm64.md b/mono/mini/cpu-arm64.md
+index 6b8488c0468..aff89052937 100644
+--- a/mono/mini/cpu-arm64.md
++++ b/mono/mini/cpu-arm64.md
+@@ -229,6 +229,7 @@ r4_conv_to_u2: dest:i src1:f len:8
+ r4_conv_to_i4: dest:i src1:f len:8
+ r4_conv_to_u4: dest:i src1:f len:8
+ r4_conv_to_i8: dest:l src1:f len:8
++r4_conv_to_i: dest:l src1:f len:8
+ r4_conv_to_u8: dest:l src1:f len:8
+ r4_conv_to_r4: dest:f src1:f len:4
+ r4_conv_to_r8: dest:f src1:f len:4
+diff --git a/mono/mini/interp/transform.c b/mono/mini/interp/transform.c
+index 7438255c6a1..60cfb37c5a2 100644
+--- a/mono/mini/interp/transform.c
++++ b/mono/mini/interp/transform.c
+@@ -4201,6 +4201,13 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header,
+ 				interp_add_ins (td, MINT_CONV_I8_R8);
+ #else
+ 				interp_add_ins (td, MINT_CONV_I4_R8);
++#endif
++				break;
++			case STACK_TYPE_R4:
++#if SIZEOF_VOID_P == 8
++				interp_add_ins (td, MINT_CONV_I8_R4);
++#else
++				interp_add_ins (td, MINT_CONV_I4_R4);
+ #endif
+ 				break;
+ 			case STACK_TYPE_I4:
+diff --git a/mono/mini/mini-arm.c b/mono/mini/mini-arm.c
+index 00c0be5fdfe..678b4a2f77a 100644
+--- a/mono/mini/mini-arm.c
++++ b/mono/mini/mini-arm.c
+@@ -5909,6 +5909,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
+ 			code = emit_r4_to_int (cfg, code, ins->dreg, ins->sreg1, 2, FALSE);
+ 			break;
+ 		case OP_RCONV_TO_I4:
++		case OP_RCONV_TO_I:
+ 			code = emit_r4_to_int (cfg, code, ins->dreg, ins->sreg1, 4, TRUE);
+ 			break;
+ 		case OP_RCONV_TO_U4:
+diff --git a/mono/mini/mini-arm64.c b/mono/mini/mini-arm64.c
+index 2dc1a5532ef..4e3688c87d4 100644
+--- a/mono/mini/mini-arm64.c
++++ b/mono/mini/mini-arm64.c
+@@ -4304,6 +4304,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
+ 			arm_fcvtzu_sx (code, dreg, sreg1);
+ 			break;
+ 		case OP_RCONV_TO_I8:
++		case OP_RCONV_TO_I:
+ 			arm_fcvtzs_sx (code, dreg, sreg1);
+ 			break;
+ 		case OP_RCONV_TO_U8:
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.147/0016-arm64-Fix-wrong-marshalling-in-gsharedvt-transition-.patch
+++ b/recipes-mono/mono/mono-6.12.0.147/0016-arm64-Fix-wrong-marshalling-in-gsharedvt-transition-.patch
@@ -1,0 +1,36 @@
+From c90ec48f596c5d18c07724c749fa13c5ad07161d Mon Sep 17 00:00:00 2001
+From: Vlad Brezae <brezaevlad@gmail.com>
+Date: Tue, 13 Apr 2021 20:13:30 +0300
+Subject: [PATCH 16/32] [arm64] Fix wrong marshalling in gsharedvt transition
+ (#21006)
+
+Transitioning from ArgVtypeByRefOnStack to ArgVtypeByRef requires no marshalling. The reference ends up being saved on stack the same way and the stack slot just needs to be copied (in mono_arm_start_gsharedvt_call).
+---
+ mono/mini/mini-arm64-gsharedvt.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/mono/mini/mini-arm64-gsharedvt.c b/mono/mini/mini-arm64-gsharedvt.c
+index 67689024464..f3a0653a03a 100644
+--- a/mono/mini/mini-arm64-gsharedvt.c
++++ b/mono/mini/mini-arm64-gsharedvt.c
+@@ -229,7 +229,7 @@ mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_si
+ 		}
+ 		if (ainfo2->storage == ArgVtypeByRef && ainfo2->gsharedvt) {
+ 			/* Pass the address of the first src slot in a reg */
+-			if (ainfo->storage != ArgVtypeByRef) {
++			if (ainfo->storage != ArgVtypeByRef && ainfo->storage != ArgVtypeByRefOnStack) {
+ 				if (ainfo->storage == ArgHFA && ainfo->esize == 4) {
+ 					arg_marshal = GSHAREDVT_ARG_BYVAL_TO_BYREF_HFAR4;
+ 					g_assert (src [0] < 64);
+@@ -244,7 +244,7 @@ mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_si
+ 			dst [0] = map_reg (ainfo2->reg);
+ 		} else if (ainfo2->storage == ArgVtypeByRefOnStack && ainfo2->gsharedvt) {
+ 			/* Pass the address of the first src slot in a stack slot */
+-			if (ainfo->storage != ArgVtypeByRef)
++			if (ainfo->storage != ArgVtypeByRef && ainfo->storage != ArgVtypeByRefOnStack)
+ 				arg_marshal = GSHAREDVT_ARG_BYVAL_TO_BYREF;
+ 			ndst = 1;
+ 			dst = g_new0 (int, 1);
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.147/0019-MonoIO-Wrap-calls-to-open-in-EINTR-handling-21042.patch
+++ b/recipes-mono/mono/mono-6.12.0.147/0019-MonoIO-Wrap-calls-to-open-in-EINTR-handling-21042.patch
@@ -1,0 +1,64 @@
+From 0449008883dfe8cf108c74ba1167f99723d5a3a3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Aleksey=20Kliger=20=28=CE=BBgeek=29?= <alklig@microsoft.com>
+Date: Fri, 30 Apr 2021 13:09:56 -0400
+Subject: [PATCH 19/32] [MonoIO] Wrap calls to open() in EINTR handling
+ (#21042)
+
+Related to https://github.com/mono/mono/issues/21040 and
+https://github.com/dotnet/runtime/issues/48663
+
+On MacOS Big Sur open() is much more likely to throw EINTR - and moreover if
+the thread receives a signal while doing an open() even if the signal handler
+is marked with SA_RESTART, the open call appears not to restart and to fail
+anyway.
+
+So wrap all the calls to open() in retry loops.
+---
+ mono/metadata/w32file-unix.c | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/mono/metadata/w32file-unix.c b/mono/metadata/w32file-unix.c
+index 819bbba6818..5430744f9d1 100644
+--- a/mono/metadata/w32file-unix.c
++++ b/mono/metadata/w32file-unix.c
+@@ -282,17 +282,23 @@ _wapi_open (const gchar *pathname, gint flags, mode_t mode)
+ 		located_filename = mono_portability_find_file (pathname, FALSE);
+ 		if (located_filename == NULL) {
+ 			MONO_ENTER_GC_SAFE;
+-			fd = open (pathname, flags, mode);
++			do {
++				fd = open (pathname, flags, mode);
++			} while (fd == -1 && errno == EINTR);
+ 			MONO_EXIT_GC_SAFE;
+ 		} else {
+ 			MONO_ENTER_GC_SAFE;
+-			fd = open (located_filename, flags, mode);
++			do {
++				fd = open (located_filename, flags, mode);
++			} while (fd == -1 && errno == EINTR);
+ 			MONO_EXIT_GC_SAFE;
+ 			g_free (located_filename);
+ 		}
+ 	} else {
+ 		MONO_ENTER_GC_SAFE;
+-		fd = open (pathname, flags, mode);
++		do {
++			fd = open (pathname, flags, mode);
++		} while (fd == -1 && errno == EINTR);
+ 		MONO_EXIT_GC_SAFE;
+ 		if (fd == -1 && (errno == ENOENT || errno == ENOTDIR) && IS_PORTABILITY_SET) {
+ 			gint saved_errno = errno;
+@@ -304,7 +310,9 @@ _wapi_open (const gchar *pathname, gint flags, mode_t mode)
+ 			}
+ 
+ 			MONO_ENTER_GC_SAFE;
+-			fd = open (located_filename, flags, mode);
++			do {
++				fd = open (located_filename, flags, mode);
++			} while (fd == -1 && errno == EINTR);
+ 			MONO_EXIT_GC_SAFE;
+ 			g_free (located_filename);
+ 		}
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.147/0020-2020-02-Fix-leak-in-assembly-specific-dllmap-lookups.patch
+++ b/recipes-mono/mono/mono-6.12.0.147/0020-2020-02-Fix-leak-in-assembly-specific-dllmap-lookups.patch
@@ -1,0 +1,80 @@
+From 28a101a8ab5a3852bcb8876edfbc9d9f1360cd35 Mon Sep 17 00:00:00 2001
+From: Ryan Lucia <rylucia@microsoft.com>
+Date: Mon, 10 May 2021 09:30:00 -0400
+Subject: [PATCH 20/32] [2020-02] Fix leak in assembly-specific dllmap lookups
+ (#21053)
+
+---
+ mono/metadata/native-library.c | 18 ++++++++++--------
+ 1 file changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/mono/metadata/native-library.c b/mono/metadata/native-library.c
+index d57252f1b1d..0f556794a38 100644
+--- a/mono/metadata/native-library.c
++++ b/mono/metadata/native-library.c
+@@ -83,9 +83,9 @@ GENERATE_GET_CLASS_WITH_CACHE (native_library, "System.Runtime.InteropServices",
+  * LOCKING: Assumes the relevant lock is held.
+  * For the global DllMap, this is `global_loader_data_mutex`, and for images it's their internal lock.
+  */
+-static int
++static gboolean
+ mono_dllmap_lookup_list (MonoDllMap *dll_map, const char *dll, const char* func, const char **rdll, const char **rfunc) {
+-	int found = 0;
++	gboolean found = FALSE;
+ 
+ 	*rdll = dll;
+ 	*rfunc = func;
+@@ -107,7 +107,7 @@ mono_dllmap_lookup_list (MonoDllMap *dll_map, const char *dll, const char* func,
+ 
+ 		if (!found && dll_map->target) {
+ 			*rdll = dll_map->target;
+-			found = 1;
++			found = TRUE;
+ 			/* we don't quit here, because we could find a full
+ 			 * entry that also matches the function, which takes priority.
+ 			 */
+@@ -120,8 +120,6 @@ mono_dllmap_lookup_list (MonoDllMap *dll_map, const char *dll, const char* func,
+ 	}
+ 
+ exit:
+-	*rdll = g_strdup (*rdll);
+-	*rfunc = g_strdup (*rfunc);
+ 	return found;
+ }
+ 
+@@ -129,10 +127,10 @@ exit:
+  * The locking and GC state transitions here are wonky due to the fact the image lock is a coop lock
+  * and the global loader data lock is an OS lock.
+  */
+-static int
++static gboolean
+ mono_dllmap_lookup (MonoImage *assembly, const char *dll, const char* func, const char **rdll, const char **rfunc)
+ {
+-	int res;
++	gboolean res;
+ 
+ 	MONO_REQ_GC_UNSAFE_MODE;
+ 
+@@ -141,7 +139,7 @@ mono_dllmap_lookup (MonoImage *assembly, const char *dll, const char* func, cons
+ 		res = mono_dllmap_lookup_list (assembly->dll_map, dll, func, rdll, rfunc);
+ 		mono_image_unlock (assembly);
+ 		if (res)
+-			return res;
++			goto leave;
+ 	}
+ 
+ 	MONO_ENTER_GC_SAFE;
+@@ -152,6 +150,10 @@ mono_dllmap_lookup (MonoImage *assembly, const char *dll, const char* func, cons
+ 
+ 	MONO_EXIT_GC_SAFE;
+ 
++leave:
++	*rdll = g_strdup (*rdll);
++	*rfunc = g_strdup (*rfunc);
++
+ 	return res;
+ }
+ 
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.147/0024-2020-02-Start-a-dedicated-thread-for-MERP-crash-repo.patch
+++ b/recipes-mono/mono/mono-6.12.0.147/0024-2020-02-Start-a-dedicated-thread-for-MERP-crash-repo.patch
@@ -1,0 +1,908 @@
+From 63035635944865e83afee8efd6c346af1c077d58 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Aleksey=20Kliger=20=28=CE=BBgeek=29?= <alklig@microsoft.com>
+Date: Wed, 23 Jun 2021 20:18:19 -0400
+Subject: [PATCH 24/32] [2020-02] Start a dedicated thread for MERP crash
+ reporting (#21126)
+
+Related to #21009.
+
+There are two scenarios:
+1.  When someone force quits Mono (or just runs `kill -TERM <pid>`), the process can receive the signal on any thread,
+2. or - if a thread in the process crashes, but the thread is not attached to the runtime, Mono's signal handlers still run.
+
+The crash reporter assumes that the crashing thread is either attached to the runtime, or at least `mono_thread_info_current` or the JIT TLS data are set for the thread.  If the thread is truly foreign and it never interacted with Mono, and it crashes, both of those assumptions are false, but Mono's crash reporter signal handlers still run.
+
+The solution from this PR is: if crash reporting is enabled, start a dedicated thread at process startup that is a "crash report leader" - when a crash happens, the crashing thread (the crash originator) wakes the leader, and the leader collects the crash report.  The crash originator does not do any work that requires being attached to the runtime or to the JIT such as iterating over thread IDs or stack walking.
+
+
+---
+
+* Add a standalone test of crash on a foreign thread
+
+* Sketch out crash leader implementation
+
+   At process startup, start a separate thread that is attached to the runtime and can collect crash reports.  Crashing threads will wake it and wait for it to collect the crash reports
+
+* Start moving responsibilities to the crash leader
+
+* Watch for nil jit_tls data if crash is on a foreign thread
+
+* Start adding a state machine for the crash leader
+
+   We need to coordinate the originator and the leader in a few places.
+
+   The leader needs to pause to after collecting the thread ids before suspending the non-originator threads, and again while the originator is dumping its own stack.
+
+   The originator needs to wait for the leader to collect the thread IDs and to tell it its assigned slot. Then it tells the leader to suspend the others, dumps its own memory, then tell the leader to dump the whole crash report and wait for it to reply when it's done.
+
+* Move remaining summarizer work to the summarizer leader thread
+
+* change some debug printfs
+
+* Successfully summarize a foreign thread crash
+
+* Add test to merp-crash-test.cs
+
+* delete standalone test
+
+* if the crash leader is the originator, collect the report synchronously
+
+   either because the crash leader crashed, or because the process got a SIGTERM and it arrived on the crash leader thread
+
+* fixup comments
+
+* turn off crash leader printf debugging
+
+* Don't create leader thread if crash reporting is disabled
+
+* Fix test on win32
+
+* Update mono/tests/libtest.c
+
+* fixup logging and comments around managed stack collection
+
+* Disable the merp dlopen crasher
+
+* Remove crash leader state machine
+
+   It's straightline code with two early exits. State machine is overkill
+
+* remove remnants of leader state machine
+---
+ mono/metadata/appdomain.c     |   5 +
+ mono/metadata/threads-types.h |   5 +
+ mono/metadata/threads.c       | 490 ++++++++++++++++++++++++++++++++--
+ mono/mini/debugger-agent.c    |   4 +
+ mono/mini/mini-exceptions.c   |  13 +-
+ mono/mini/mini-runtime.c      |   2 +
+ mono/tests/libtest.c          |  28 ++
+ mono/tests/merp-crash-test.cs |  12 +-
+ mono/utils/hazard-pointer.c   |   2 +-
+ 9 files changed, 530 insertions(+), 31 deletions(-)
+
+diff --git a/mono/metadata/appdomain.c b/mono/metadata/appdomain.c
+index 724f4ea9a6b..95f3dcabc09 100644
+--- a/mono/metadata/appdomain.c
++++ b/mono/metadata/appdomain.c
+@@ -345,6 +345,11 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
+ 
+ 	mono_thread_attach (domain);
+ 
++#ifndef DISABLE_CRASH_REPORTING
++	if (!mono_runtime_get_no_exec ()) 
++		mono_summarizer_create_leader_thread ();
++#endif
++	
+ 	mono_type_initialization_init ();
+ 
+ 	if (!mono_runtime_get_no_exec ())
+diff --git a/mono/metadata/threads-types.h b/mono/metadata/threads-types.h
+index dc06fb56538..8a0fa9de244 100644
+--- a/mono/metadata/threads-types.h
++++ b/mono/metadata/threads-types.h
+@@ -569,4 +569,9 @@ mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *ha
+ gboolean
+ mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx);
+ 
++#ifndef DISABLE_CRASH_REPORTING
++void
++mono_summarizer_create_leader_thread (void);
++#endif
++
+ #endif /* _MONO_METADATA_THREADS_TYPES_H_ */
+diff --git a/mono/metadata/threads.c b/mono/metadata/threads.c
+index 5354a51b9e7..2cafb71bba5 100644
+--- a/mono/metadata/threads.c
++++ b/mono/metadata/threads.c
+@@ -6351,6 +6351,302 @@ summarizer_supervisor_end (SummarizerSupervisorState *state)
+ }
+ #endif
+ 
++/**
++ *
++ * Why a summarizer leader thread?
++ *
++ * The issue is that we set up signal handlers globally for all sorts of
++ * process-wide problems: sigsegv, sigterm, etc.  Which means that if a thread
++ * is created outside of the control of Mono, our signal handlers may still run
++ * on those threads.  But one of the things we need to do is interact with our
++ * thread state machinery, enumerate managed threads, etc - things that are
++ * generally not possible to do from an unattached thread.  We have a choice:
++ * we can either attach in the signal handler or we can punt the crash data
++ * collection to a thread that we know is already running and is in a healthy
++ * state.  Attaching in a signal handler is unlikely to work (attaching is not
++ * async signal safe).  So instead we initialize a crash report leader thread
++ * at startup, and ask it to collect the crash report on our behalf.
++ * 
++ *
++ * The order of operations is:
++ * - at startup:
++ *   - main thread starts leader thread
++ *   - leader thread starts, toggles leader_running and waits for begin_crash_report
++ * - to report a crash:
++ *   - mono_threads_summarize gates the crashes so only one thread originates a crash report at a time
++ *   - originating thread writes its info to the leader and posts to begin_crash_report.
++ *   - leader wakes up, copies the originator data, starts collecting a crash report
++ *   - leader and originator coordinate via leader_commanded and the response_fds to collect a crash report
++ *   - orignator returns to mono_threads_summarize, unblocks the next crash originator, if any, and then returns (which sends off the crash report in some way).
++ */
++
++typedef struct _MonoSummarizerOriginator {
++	/* in data */
++	SummarizerGlobalState *state;
++	MonoNativeThreadId originator_tid;
++	MonoContext *originator_ctx;
++	gchar *working_mem; /* in-data: memory for the summary report and its size */
++	size_t provided_size;
++	gchar **out; /* pointer into working_mem containing the output string */
++	/* in data - set after the originator dumps itself, while leader is waiting for all threads */
++	MonoThreadSummary *originator_summary;
++	/* out data */
++	/* index of originator thread in list of threads collected by the leader */
++	int originator_index;
++} MonoSummarizerOriginator;
++
++
++typedef struct _MonoSummarizerLeader {
++	MonoNativeThreadId leader_tid;
++	int32_t leader_running; /* only atomic reads */
++	MonoSemType begin_crash_report;
++	/* originator cant post commands to the leader */
++	MonoSemType leader_commanded;
++	int leader_command;
++	/* pipe to communicate back from the summarizer leader to the originator */
++	int response_fds[2];
++	/* Only one orignator at a time, gated by mono_threads_summarize tickets */
++	MonoSummarizerOriginator originator;
++} MonoSummarizerLeader;
++
++static MonoSummarizerLeader summarizer_leader_data;
++
++/* Commands from crash originator to the crash leader */
++enum LeaderCommand {
++	LEADER_COMMAND_ZERO = 0, /* not used */
++	LEADER_COMMAND_CANCEL = -1,
++	LEADER_COMMAND_PROCEED_TO_SUSPEND = 1,
++	LEADER_COMMAND_PROCEED_TO_TERM = 2,
++};
++
++/* Responses from the crash leader to the crash originator */
++enum LeaderResponse {
++	LEADER_RESPONSE_IDS_COLLECTED = 1,
++	LEADER_RESPONSE_THREADS_SUSPENDED = 2,
++	LEADER_RESPONSE_STACKS_WALKED = 3,
++};
++
++/* Uncomment to get additional debugging code in the crash leader */
++/* #define LEADER_DEBUG */
++
++#ifdef LEADER_DEBUG
++#define LEADER_LOG(...) g_async_safe_printf (__VA_ARGS__)
++#else
++#define LEADER_LOG(...) /*empty*/
++#endif
++
++/* Called by the leader to send responses to the originator */
++static void
++summarizer_leader_response_write (char b)
++{
++	int res;
++	LEADER_LOG ("leader --> originator: %d\n", (int)b);
++	while ((res = write (summarizer_leader_data.response_fds[1], &b, sizeof (b))) < 0 && errno == EINTR);
++}
++
++/* Called by the originator to receive (blocking) responses from the leader */
++static int
++summarizer_leader_response_read (void)
++{
++	char buf;
++	int nread = 0;
++	do {
++		int res = read(summarizer_leader_data.response_fds[0], &buf, sizeof (buf));
++		if (res < 0) {
++			if (errno == EINTR)
++				continue;
++			else
++				return -1;
++		}
++		nread += res;
++	} while (nread < sizeof (buf));
++	LEADER_LOG ("originator <---- leader : %d\n", (int)buf);
++	return (int)buf;
++}
++
++/* Called by the leader to wait for a command from the crash originator */
++static gboolean
++summarizer_leader_wait_for_command (int *leader_command)
++{
++	MONO_ENTER_GC_SAFE;
++	/* allow interruptions */
++	while (mono_os_sem_wait (&summarizer_leader_data.leader_commanded, MONO_SEM_FLAGS_ALERTABLE) < 0);
++	MONO_EXIT_GC_SAFE;
++	*leader_command = summarizer_leader_data.leader_command;
++	if (*leader_command == LEADER_COMMAND_CANCEL) {
++		return FALSE;
++	}
++	return TRUE;
++}
++
++
++/* Called by the originator to post commands to the leader.  Usually just to proceed to the next state */
++static void
++summarizer_leader_post_command (int command)
++{
++	summarizer_leader_data.leader_command = command;
++	mono_os_sem_post (&summarizer_leader_data.leader_commanded);
++}
++
++static void
++summarizer_leader_collect_thread_ids (SummarizerGlobalState *state);
++static void
++summarizer_leader_suspend_others (SummarizerGlobalState *state, MonoNativeThreadId originator, int originator_idx);
++static void
++summarizer_leader_set_originator_summary (MonoThreadSummary *orignator_summary);
++static void
++summarizer_state_get_index_for_thread (SummarizerGlobalState *state, MonoNativeThreadId current, int *my_index);
++static void
++summarizer_state_wait_and_term (MonoNativeThreadId caller_tid, SummarizerGlobalState *state, gchar **out, gchar *working_mem, size_t provided_size, MonoThreadSummary *originator_summary);
++static void
++summarizer_leader_adjust_tids_for_foreign_originator (void);
++
++static void
++summarizer_leader (void)
++{
++	MonoInternalThread *thread = mono_thread_internal_current ();
++	thread->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
++
++	/*
++	 * This thread must not be stopped by the profiler or the STW
++	 * machinery. While collecting crashes it also violates the coop GC
++	 * rules by accessing managed memory to gather crash reports.  But
++	 * crash reporting has its own signal-based mechanism to interrupt the
++	 * other threads, so this is okay.
++	 */
++	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);
++
++	mono_thread_set_name_constant_ignore_error (thread, "Crash Report Leader", MonoSetThreadNameFlag_None);
++
++	mono_thread_set_state (mono_thread_internal_current (), ThreadState_Background);
++
++	/* This thread is always in async context */
++	mono_thread_info_set_is_async_context (TRUE);
++	
++	mono_atomic_store_i32 (&summarizer_leader_data.leader_running, 1);
++	while (TRUE) {
++		/* Leader ready to receive crashe report requests */
++		MONO_ENTER_GC_SAFE;
++		/* allow interruptions */
++		while (mono_os_sem_wait (&summarizer_leader_data.begin_crash_report, MONO_SEM_FLAGS_ALERTABLE) < 0);
++		MONO_EXIT_GC_SAFE;
++		LEADER_LOG ("Crash report leader %p beginning collection for originator %p\n", (gpointer)(intptr_t)summarizer_leader_data.leader_tid, (gpointer)(intptr_t)summarizer_leader_data.originator.originator_tid);
++
++		/* Leader is collecting thread ids for a crash */
++
++		/* collect a crash report */
++		summarizer_leader_collect_thread_ids (summarizer_leader_data.originator.state);
++
++		summarizer_leader_data.originator.originator_index = -1;
++		summarizer_state_get_index_for_thread (summarizer_leader_data.originator.state, summarizer_leader_data.originator.originator_tid, &summarizer_leader_data.originator.originator_index);
++		if (summarizer_leader_data.originator.originator_index == -1)
++			summarizer_leader_adjust_tids_for_foreign_originator ();
++
++		/* wake up originator */
++		summarizer_leader_response_write (LEADER_RESPONSE_IDS_COLLECTED);
++
++		/* Leader is waiting for report originator before suspending the other threads */
++		int cmd;
++		if (!summarizer_leader_wait_for_command (&cmd))
++			continue; /* restart */
++		g_assert (cmd == LEADER_COMMAND_PROCEED_TO_SUSPEND);
++
++		/* Leader is suspending other threads */
++		summarizer_leader_suspend_others(summarizer_leader_data.originator.state, summarizer_leader_data.originator.originator_tid, summarizer_leader_data.originator.originator_index);
++		summarizer_leader_response_write (LEADER_RESPONSE_THREADS_SUSPENDED);
++
++		/* Pause leader until originator populates its stack data */
++
++		if (!summarizer_leader_wait_for_command (&cmd))
++			continue;
++		g_assert (cmd == LEADER_COMMAND_PROCEED_TO_TERM);
++
++		/* Finish up the crash report */
++		summarizer_state_wait_and_term (summarizer_leader_data.leader_tid, summarizer_leader_data.originator.state, summarizer_leader_data.originator.out, summarizer_leader_data.originator.working_mem, summarizer_leader_data.originator.provided_size, summarizer_leader_data.originator.originator_summary);
++		LEADER_LOG ("Crash report leader finished reporting.  Ready for next crash\n");
++		summarizer_leader_response_write (LEADER_RESPONSE_STACKS_WALKED);
++	}
++}
++
++static gboolean
++summarizer_leader_is_running (void)
++{
++	return mono_atomic_load_i32 (&summarizer_leader_data.leader_running);
++}
++
++
++static void
++summarizer_leader_init (void)
++{
++	/* TODO: do we really need two semaphores?  There's always one
++	 * originator and one leader - we can signal the leader to begin by
++	 * posting a command. */
++	mono_os_sem_init (&summarizer_leader_data.begin_crash_report, 0);
++	mono_os_sem_init (&summarizer_leader_data.leader_commanded, 0);
++	/* Can't create the leader thread early on because MonoInternalThread needs the corlib InternalThread type */
++	int res = pipe (summarizer_leader_data.response_fds);
++	g_assert (!res);
++}
++
++void
++mono_summarizer_create_leader_thread (void)
++{
++	ERROR_DECL (error);
++
++	MonoInternalThread *leader = mono_thread_create_internal (mono_get_root_domain (), summarizer_leader, NULL, MONO_THREAD_CREATE_FLAGS_NONE, error);
++	mono_error_assert_ok (error);
++
++	summarizer_leader_data.leader_tid = thread_get_tid (leader);
++}
++static void
++summarizer_originator_prepare (MonoSummarizerOriginator *orig, SummarizerGlobalState *state, MonoNativeThreadId tid, MonoContext *ctx, gchar **out, gchar *working_mem, size_t provided_size)
++{
++	orig->state = state;
++	orig->originator_tid = tid;
++	orig->originator_ctx = ctx;
++	orig->out = out;
++	orig->working_mem = working_mem;
++	orig->provided_size = provided_size;
++}
++
++static void
++summarizer_leader_set_originator_summary (MonoThreadSummary *originator_summary)
++{
++	summarizer_leader_data.originator.originator_summary = originator_summary;
++}
++
++
++/* returns 0 if leader is not running and crash reporting should be done on the originator thread.
++ * returns <0 if leader could not collect a crash report.
++ * otherwise returns 1
++ */
++static int
++summarizer_originate_crash_report (SummarizerGlobalState *state, MonoNativeThreadId originator_tid, MonoContext *ctx, gchar **out, gchar *working_mem, size_t provided_size)
++{
++	/* FIXME: we already have a mechanism for gating requests in mono_threads_summarize, don't need another one here */
++	if (!summarizer_leader_is_running ()) {
++		/* FIXME: in that case, just gather the crash report on the main thread - it's early during startup */
++		g_async_safe_printf ("crash summarizer leader thread is not running. collecting crash report syncronously.\n");
++		return 0;
++	}
++
++	if (mono_native_thread_id_equals (originator_tid, summarizer_leader_data.leader_tid)) {
++		g_async_safe_printf ("crash summarizer leader thread crashed.  collecting a crash report synchronously\n");
++		/* Make it look like there's no summarizer leader */
++		mono_atomic_store_i32 (&summarizer_leader_data.leader_running, 0);
++		memset (&summarizer_leader_data.leader_tid, 0, sizeof (summarizer_leader_data.leader_tid));
++		/* Collect the crash report synchronously on this thread */
++		return 0;
++	}
++
++	summarizer_originator_prepare (&summarizer_leader_data.originator, state, originator_tid, ctx, out, working_mem, provided_size);
++	/* we're intentionally not switching to GC Safe mode in case we crashed in the coop state machine */
++	mono_os_sem_post (&summarizer_leader_data.begin_crash_report);
++
++	return summarizer_leader_response_read ();
++}
++
++
+ static void
+ collect_thread_id (gpointer key, gpointer value, gpointer user)
+ {
+@@ -6382,24 +6678,67 @@ collect_thread_ids (MonoNativeThreadId *thread_ids, int max_threads)
+ 	return ud.nthreads;
+ }
+ 
++
++/*
++ * Try to initialize the global summarizer thread.  At this point the caller
++ * doesn't know if it's the crash originator, or if another crash is in
++ * progress and the current thread was asked to summarize its state.  Returns
++ * TRUE if the current thread is to be the crash originator, returns FALSE if
++ * there's already a crash collection in progress.
++ */
+ static gboolean
+-summarizer_state_init (SummarizerGlobalState *state, MonoNativeThreadId current, int *my_index)
++summarizer_state_init (SummarizerGlobalState *state)
+ {
+ 	gint32 started_state = mono_atomic_cas_i32 (&state->has_owner, 1 /* set */, 0 /* compare */);
+ 	gboolean not_started = started_state == 0;
+-	if (not_started) {
+-		state->nthreads = collect_thread_ids (state->thread_array, MAX_NUM_THREADS);
++	if (not_started)
+ 		mono_os_sem_init (&state->update, 0);
++	return not_started;
++}
++
++static void
++summarizer_state_collect_thread_ids (SummarizerGlobalState *state)
++{
++	state->nthreads = collect_thread_ids (state->thread_array, MAX_NUM_THREADS);
++}
++
++static void
++summarizer_leader_collect_thread_ids (SummarizerGlobalState *state)
++{
++	summarizer_state_collect_thread_ids (state);
++
++}
++
++static void
++summarizer_leader_adjust_tids_for_foreign_originator (void)
++{
++	if (summarizer_leader_data.originator.originator_index == -1) {
++		/* The crash originator is not in Mono's thread list - it's some foreign thread that crashed in native code */
++		/* Add a slot for it at the end of the summarizer global state */
++		SummarizerGlobalState *state = summarizer_leader_data.originator.state;
++		if (state->nthreads < MAX_NUM_THREADS - 1) {
++			int originator_index = state->nthreads++;
++			state->thread_array [originator_index] = summarizer_leader_data.originator.originator_tid;
++			summarizer_leader_data.originator.originator_index = originator_index;
++		}
+ 	}
++}
+ 
++static int
++summarizer_leader_get_originator_index (void)
++{
++	return summarizer_leader_data.originator.originator_index;
++}
++
++static void
++summarizer_state_get_index_for_thread (SummarizerGlobalState *state, MonoNativeThreadId current, int *my_index)
++{
+ 	for (int i = 0; i < state->nthreads; i++) {
+ 		if (state->thread_array [i] == current) {
+ 			*my_index = i;
+ 			break;
+ 		}
+ 	}
+-
+-	return not_started;
+ }
+ 
+ static void
+@@ -6414,23 +6753,38 @@ summarizer_signal_other_threads (SummarizerGlobalState *state, MonoNativeThreadI
+ 
+ 		if (i == current_idx)
+ 			continue;
++		MonoNativeThreadId tid = state->thread_array [i];
++
++		if (mono_native_thread_id_equals (tid, summarizer_leader_data.leader_tid))
++			continue;
++		
+ 	#ifdef HAVE_PTHREAD_KILL
+ 		pthread_kill (state->thread_array [i], SIGTERM);
+ 
+ 		if (!state->silent)
+-			g_async_safe_printf("Pkilling 0x%" G_GSIZE_FORMAT "x from 0x%" G_GSIZE_FORMAT "x\n", (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (state->thread_array [i]), (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (current));
++			g_async_safe_printf("Pkilling %p from %p\n", (gpointer)(intptr_t) state->thread_array [i], (gpointer)(intptr_t)current);
+ 	#else
+ 		g_error ("pthread_kill () is not supported by this platform");
+ 	#endif
+ 	}
+ }
+ 
++static void
++summarizer_leader_suspend_others (SummarizerGlobalState *state, MonoNativeThreadId originator, int originator_idx)
++{
++	summarizer_signal_other_threads (state, originator, originator_idx);
++}
++
+ // Returns true when there are shared global references to "this_thread"
+ static gboolean
+ summarizer_post_dump (SummarizerGlobalState *state, MonoThreadSummary *this_thread, int current_idx)
+ {
+ 	mono_memory_barrier ();
+ 
++	/* If the thread wasn't assigned a slot, don't save its dump */
++	if (current_idx < 0)
++		return FALSE;
++
+ 	gpointer old = mono_atomic_cas_ptr ((volatile gpointer *)&state->all_threads [current_idx], this_thread, NULL);
+ 
+ 	if (old == GINT_TO_POINTER (-1)) {
+@@ -6504,20 +6858,24 @@ summarizer_state_term (SummarizerGlobalState *state, gchar **out, gchar *mem, si
+ 	mono_summarize_timeline_phase_log (MonoSummaryManagedStacks);
+ 	for (int i=0; i < state->nthreads; i++) {
+ 		threads [i] = summarizer_try_read_thread (state, i);
++		LEADER_LOG("managed stack for thread %d (%p) \"%s\"\n", i, threads[i] ? (gpointer)threads[i]->native_thread_id : (gpointer)NULL, threads[i] && threads[i]->name[0] != '\0' ? threads[i]->name : "");
+ 		if (!threads [i])
+ 			continue;
+ 
+-		// We are doing this dump on the controlling thread because this isn't
++		// We are doing this dump on the leader or controlling thread because this isn't
+ 		// an async context sometimes. There's still some reliance on malloc here, but it's
+-		// much more stable to do it all from the controlling thread.
++		// much more stable to do it all from the leader or controlling thread.
+ 		//
+ 		// This is non-null, checked in mono_threads_summarize
+ 		// with early exit there
+ 		mono_get_eh_callbacks ()->mono_summarize_managed_stack (threads [i]);
++
++		LEADER_LOG("finished managed stack for thread %d (%p)\n", i, threads[i] ? (gpointer)threads[i]->native_thread_id : (gpointer)NULL);
+ 	}
+ 
+ 	/* The value of the breadcrumb should match the "StackHash" value written by `mono_merp_write_fingerprint_payload` */
+ 	mono_create_crash_hash_breadcrumb (controlling);
++	LEADER_LOG("wrote hash breadcrumb for controlling thread %p", controlling ? (gpointer)controlling->native_thread_id : (gpointer)NULL);
+ 
+ 	MonoStateWriter writer;
+ 	memset (&writer, 0, sizeof (writer));
+@@ -6555,6 +6913,22 @@ summarizer_state_wait (MonoThreadSummary *thread)
+ 		mono_os_sem_timedwait (&thread->done_wait, milliseconds_in_second, MONO_SEM_FLAGS_NONE);
+ }
+ 
++static void
++summarizer_state_wait_and_term (MonoNativeThreadId caller_tid, SummarizerGlobalState *state, gchar **out, gchar *working_mem, size_t provided_size, MonoThreadSummary *originator_summary)
++{
++	if (!state->silent)
++		g_async_safe_printf("Entering thread summarizer pause from %p\n", (gpointer)(intptr_t)caller_tid);
++
++	// Wait up to 2 seconds for all of the other threads to catch up
++	summary_timedwait (state, 2);
++
++	if (!state->silent)
++		g_async_safe_printf("Finished thread summarizer pause from %p.\n", (gpointer)(intptr_t)caller_tid);
++
++	// Dump and cleanup all the stack memory
++	summarizer_state_term (state, out, working_mem, provided_size, originator_summary);
++}
++
+ static gboolean
+ mono_threads_summarize_execute_internal (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gchar *working_mem, size_t provided_size, gboolean this_thread_controls)
+ {
+@@ -6562,10 +6936,56 @@ mono_threads_summarize_execute_internal (MonoContext *ctx, gchar **out, MonoStac
+ 
+ 	int current_idx;
+ 	MonoNativeThreadId current = mono_native_thread_id_get ();
+-	gboolean thread_given_control = summarizer_state_init (&state, current, &current_idx);
++	gboolean thread_given_control = summarizer_state_init (&state);
+ 
+ 	g_assert (this_thread_controls == thread_given_control);
+ 
++	/* if true, the crash leader is not running yet - collect the report on the current originating thread */
++	gboolean collect_synchronously = FALSE;
++	if (this_thread_controls) {
++		int res = summarizer_originate_crash_report (&state, current, ctx, out, working_mem, provided_size);
++		
++		/*
++		 * We need to coordinate the originator and the leader in a few
++		 * places.
++		 * 
++		 * The leader needs to pause to after collecting the thread ids
++		 * before suspending the non-originator threads, and again
++		 * while the originator is dumping its own stack.
++		 * 
++		 * The originator needs to wait for the leader to collect the
++		 * thread IDs and to tell it its assigned slot. Then it tells
++		 * the leader to suspend the others, dumps its own memory, then
++		 * tell the leader to dump the whole crash report and waits for
++		 * it to reply when it's done.
++		 */
++				
++		if (res == 0) {
++			/* collect the crash report synchronously */
++			collect_synchronously = TRUE;
++		} else if (res < 0) {
++			g_async_safe_printf ("Crash summary leader could not collect thread data.  No crash report will be created.\n");
++			/* something went wrong */
++			return FALSE;
++		} else {
++			g_assert (res == LEADER_RESPONSE_IDS_COLLECTED);
++			/* get the thread index from the crash leader */
++			current_idx = summarizer_leader_get_originator_index ();
++			if (current_idx < 0) {
++				g_async_safe_printf ("Summarizer originator not in the thread list\n");
++			} else {
++				LEADER_LOG ("Summarizer originator has index %d\n", current_idx);
++			}
++		}
++	}
++
++	if (this_thread_controls && collect_synchronously) {
++		summarizer_state_collect_thread_ids (&state);
++	}
++
++	if (!this_thread_controls || collect_synchronously)
++		summarizer_state_get_index_for_thread (&state, current, &current_idx);
++
+ 	if (state.nthreads == 0) {
+ 		if (!silent)
+ 			g_async_safe_printf("No threads attached to runtime.\n");
+@@ -6574,18 +6994,31 @@ mono_threads_summarize_execute_internal (MonoContext *ctx, gchar **out, MonoStac
+ 	}
+ 
+ 	if (this_thread_controls) {
+-		g_assert (working_mem);
+-
+ 		mono_summarize_timeline_phase_log (MonoSummarySuspendHandshake);
+ 		state.silent = silent;
+-		summarizer_signal_other_threads (&state, current, current_idx);
++		if (!collect_synchronously) {
++			/*
++			 * crash leader signals the other threads, but not the
++			 * originator thread - we're going to dump by
++			 * ourselves, below.
++			 */
++			summarizer_leader_post_command (LEADER_COMMAND_PROCEED_TO_SUSPEND);
++			int res = summarizer_leader_response_read ();
++			g_assert (res == LEADER_RESPONSE_THREADS_SUSPENDED);
++		} else {
++			summarizer_signal_other_threads (&state, current, current_idx);
++		}
+ 		mono_summarize_timeline_phase_log (MonoSummaryUnmanagedStacks);
+ 	}
+ 
+ 	MonoStateMem mem;
+ 	gboolean success = mono_state_alloc_mem (&mem, (long) current, sizeof (MonoThreadSummary));
+-	if (!success)
++	if (!success) {
++		if (this_thread_controls && !collect_synchronously) {
++			summarizer_leader_post_command (LEADER_COMMAND_CANCEL);
++		}
+ 		return FALSE;
++	}
+ 
+ 	MonoThreadSummary *this_thread = (MonoThreadSummary *) mem.mem;
+ 
+@@ -6597,24 +7030,23 @@ mono_threads_summarize_execute_internal (MonoContext *ctx, gchar **out, MonoStac
+ 		// Store a reference to our stack memory into global state
+ 		gboolean success = summarizer_post_dump (&state, this_thread, current_idx);
+ 		if (!success && !state.silent)
+-			g_async_safe_printf("Thread 0x%" G_GSIZE_FORMAT "x reported itself.\n", (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (current));
++			g_async_safe_printf("Thread %p reported itself.\n", (gpointer)(intptr_t)current);
+ 	} else if (!state.silent) {
+-		g_async_safe_printf("Thread 0x%" G_GSIZE_FORMAT "x couldn't report itself.\n", (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (current));
++		g_async_safe_printf("Thread %p couldn't report itself.\n", (gpointer)(intptr_t)current);
+ 	}
+ 
+ 	// From summarizer, wait and dump.
+ 	if (this_thread_controls) {
+-		if (!state.silent)
+-			g_async_safe_printf("Entering thread summarizer pause from 0x%" G_GSIZE_FORMAT "x\n", (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (current));
+-
+-		// Wait up to 2 seconds for all of the other threads to catch up
+-		summary_timedwait (&state, 2);
+-
+-		if (!state.silent)
+-			g_async_safe_printf("Finished thread summarizer pause from 0x%" G_GSIZE_FORMAT "x.\n", (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (current));
+-
+-		// Dump and cleanup all the stack memory
+-		summarizer_state_term (&state, out, working_mem, provided_size, this_thread);
++		if (collect_synchronously) {
++			summarizer_state_wait_and_term (current, &state, out, working_mem, provided_size, this_thread);
++		} else {
++			summarizer_leader_set_originator_summary (this_thread);
++			summarizer_leader_post_command (LEADER_COMMAND_PROCEED_TO_TERM);
++			/* blocks here until leader is done, keeping
++			 * originator's stack memory alive for the dumper */
++			int res = summarizer_leader_response_read ();
++			g_assert (res == LEADER_RESPONSE_STACKS_WALKED);
++		}
+ 	} else {
+ 		// Wait here, keeping our stack memory alive
+ 		// for the dumper
+@@ -6634,6 +7066,7 @@ void
+ mono_threads_summarize_init (void)
+ {
+ 	summarizer_supervisor_init ();
++	summarizer_leader_init ();
+ }
+ 
+ gboolean
+@@ -6660,6 +7093,7 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gb
+ 	static gint64 request_available_to_run = 1;
+ 	gint64 this_request_id = mono_atomic_inc_i64 ((volatile gint64 *) &next_pending_request_id);
+ 
++	g_async_safe_printf ("Thread %p starting summarize_execute\n", (gpointer)(intptr_t)mono_native_thread_id_get ());
+ 	// This is a global queue of summary requests. 
+ 	// It's not safe to signal a thread while they're in the
+ 	// middle of a dump. Dladdr is not reentrant. It's the one lock
+@@ -6682,13 +7116,15 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gb
+ 		gint64 next_request_id = mono_atomic_load_i64 ((volatile gint64 *) &request_available_to_run);
+ 
+ 		if (next_request_id == this_request_id) {
+-			gboolean already_async = mono_thread_info_is_async_context ();
++			gboolean foreign = mono_thread_info_current_unchecked () == NULL;
++			gboolean already_async = foreign || mono_thread_info_is_async_context ();
+ 			if (!already_async)
+ 				mono_thread_info_set_is_async_context (TRUE);
+ 
+ 			SummarizerSupervisorState synch;
+ 			if (summarizer_supervisor_start (&synch)) {
+ 				g_assert (mem);
++				
+ 				success = mono_threads_summarize_execute_internal (ctx, out, hashes, silent, mem, provided_size, TRUE);
+ 				summarizer_supervisor_end (&synch);
+ 			}
+diff --git a/mono/mini/debugger-agent.c b/mono/mini/debugger-agent.c
+index 54c0ca97801..b2787edce48 100644
+--- a/mono/mini/debugger-agent.c
++++ b/mono/mini/debugger-agent.c
+@@ -5161,6 +5161,10 @@ ss_clear_for_assembly (SingleStepReq *req, MonoAssembly *assembly)
+ static void
+ mono_debugger_agent_send_crash (char *json_dump, MonoStackHash *hashes, int pause)
+ {
++	/* Did we crash on an unattached thread?  Can't do runtime notifications from there */
++	if (!mono_thread_info_current_unchecked ())
++		return;
++
+ 	MONO_ENTER_GC_UNSAFE;
+ #ifndef DISABLE_CRASH_REPORTING
+ 	int suspend_policy;
+diff --git a/mono/mini/mini-exceptions.c b/mono/mini/mini-exceptions.c
+index e712a623bb4..643450f2fd1 100644
+--- a/mono/mini/mini-exceptions.c
++++ b/mono/mini/mini-exceptions.c
+@@ -1751,6 +1751,10 @@ mono_summarize_unmanaged_stack (MonoThreadSummary *out)
+ 	// Summarize unmanaged stack
+ 	// 
+ #ifdef HAVE_BACKTRACE_SYMBOLS
++	MonoDomain *domain = mono_domain_get ();
++
++	gboolean has_jit_tls = mono_tls_get_jit_tls () != NULL;
++
+ 	intptr_t frame_ips [MONO_MAX_SUMMARY_FRAMES];
+ 
+ 	out->num_unmanaged_frames = backtrace ((void **)frame_ips, MONO_MAX_SUMMARY_FRAMES);
+@@ -1761,11 +1765,16 @@ mono_summarize_unmanaged_stack (MonoThreadSummary *out)
+ 		const char* module_buf = frame->unmanaged_data.module;
+ 		int success = mono_get_portable_ip (ip, &frame->unmanaged_data.ip, &frame->unmanaged_data.offset, &module_buf, (char *) frame->str_descr);
+ 
++		/* If the thread is not attached to the JIT, (ie crashed native
++		 * thread), don't try to look for managed method info - it will
++		 * assert in mono_jit_info_table_find_internal */
++		if (!has_jit_tls)
++			continue;
++
+ 		/* attempt to look up any managed method at that ip */
+ 		/* TODO: Trampolines - follow examples from mono_print_method_from_ip() */
+ 
+ 		MonoJitInfo *ji;
+-		MonoDomain *domain = mono_domain_get ();
+ 		MonoDomain *target_domain;
+ 		ji = mini_jit_info_table_find_ext (domain, (char *)ip, TRUE, &target_domain);
+ 		if (ji) {
+@@ -1796,7 +1805,7 @@ mono_summarize_unmanaged_stack (MonoThreadSummary *out)
+ 
+ 	MonoThreadInfo *thread = mono_thread_info_current_unchecked ();
+ 	out->info_addr = (intptr_t) thread;
+-	out->jit_tls = thread->jit_data;
++	out->jit_tls = thread ? thread->jit_data : NULL;
+ 	out->domain = mono_domain_get ();
+ 
+ 	if (!out->ctx) {
+diff --git a/mono/mini/mini-runtime.c b/mono/mini/mini-runtime.c
+index 4619638f31b..e04626d7ff2 100644
+--- a/mono/mini/mini-runtime.c
++++ b/mono/mini/mini-runtime.c
+@@ -3351,6 +3351,8 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
+ 			mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
+ 			return;
+ 		}
++		/* thread not registered with the runtime, make sure we return now. */
++		return;
+ 	}
+ #endif
+ 
+diff --git a/mono/tests/libtest.c b/mono/tests/libtest.c
+index e5e5f2f14d3..2af1ef5302b 100644
+--- a/mono/tests/libtest.c
++++ b/mono/tests/libtest.c
+@@ -8118,6 +8118,34 @@ mono_test_MerpCrashSignalIll (void)
+ #endif
+ }
+ 
++#ifndef HOST_WIN32
++void*
++foreign_thread_crash_body (void* ud)
++{
++	while (1) {
++		fprintf (stderr, "alive\n");
++		sleep (2);
++	}
++	return NULL;
++}
++#endif
++
++LIBTEST_API void mono_test_MerpCrashOnForeignThread (void)
++{
++
++#ifndef HOST_WIN32
++	pthread_t t;
++	int res;
++
++	res = pthread_create (&t, NULL, foreign_thread_crash_body, NULL);
++
++	sleep (1);
++	pthread_kill (t, SIGILL);
++
++	pthread_join (t, NULL);
++#endif
++}
++
+ #ifdef __cplusplus
+ } // extern C
+ #endif
+diff --git a/mono/tests/merp-crash-test.cs b/mono/tests/merp-crash-test.cs
+index d534a64fae5..93a9426c45d 100644
+--- a/mono/tests/merp-crash-test.cs
++++ b/mono/tests/merp-crash-test.cs
+@@ -55,7 +55,8 @@ static CrasherClass ()
+ 			Crashers.Add(new Crasher ("MerpCrashExceptionHook", MerpCrashUnhandledExceptionHook));
+ 
+ 			// Specific Edge Cases
+-			Crashers.Add(new Crasher ("MerpCrashDladdr", MerpCrashDladdr));
++			//FIXME: crash in dlopen holds the global dyld lock, which we need for stack walks.
++			//Crashers.Add(new Crasher ("MerpCrashDladdr", MerpCrashDladdr));
+ 			Crashers.Add(new Crasher ("MerpCrashSnprintf", MerpCrashSnprintf));
+ 			Crashers.Add(new Crasher ("MerpCrashDomainUnload", MerpCrashDomainUnload));
+ 			Crashers.Add(new Crasher ("MerpCrashUnbalancedGCSafe", MerpCrashUnbalancedGCSafe));
+@@ -66,6 +67,7 @@ static CrasherClass ()
+ 			Crashers.Add(new Crasher  ("MerpCrashSignalSegv", MerpCrashSignalSegv));
+ 			Crashers.Add(new Crasher  ("MerpCrashSignalIll", MerpCrashSignalIll));
+ 			Crashers.Add(new Crasher ("MerpCrashTestBreadcrumbs", MerpCrashTestBreadcrumbs, validator: ValidateBreadcrumbs));
++			Crashers.Add(new Crasher ("MerpCrashOnForeignThread", MerpCrashOnForeignThread));
+ 		}
+ 
+ 		public static void 
+@@ -245,6 +247,14 @@ public static void
+ 			mono_test_MerpCrashSignalSegv ();
+ 		}
+ 
++		[DllImport("libtest")]
++		public static extern void mono_test_MerpCrashOnForeignThread ();
++
++		public static void
++		MerpCrashOnForeignThread ()
++		{
++			mono_test_MerpCrashOnForeignThread ();
++		}
+ 
+ 		private static object jsonGetKey (object o, string key) => (o as Dictionary<string,object>)[key];
+ 		private static object jsonGetKeys (object o, params string[] keys) {
+diff --git a/mono/utils/hazard-pointer.c b/mono/utils/hazard-pointer.c
+index 8fe373e64fb..e01912d8121 100644
+--- a/mono/utils/hazard-pointer.c
++++ b/mono/utils/hazard-pointer.c
+@@ -187,7 +187,7 @@ mono_hazard_pointer_get (void)
+ 
+ 	if (small_id < 0) {
+ 		static MonoThreadHazardPointers emerg_hazard_table;
+-		g_warning ("Thread %p may have been prematurely finalized", (gpointer) (gsize) mono_native_thread_id_get ());
++		g_warning ("Thread %p may have been prematurely finalized\n", (gpointer) (gsize) mono_native_thread_id_get ());
+ 		return &emerg_hazard_table;
+ 	}
+ 
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.147/0025-2020-02-Fix-memory-leak-during-data-registration-211.patch
+++ b/recipes-mono/mono/mono-6.12.0.147/0025-2020-02-Fix-memory-leak-during-data-registration-211.patch
@@ -1,0 +1,85 @@
+From 35bf914659f88753c1c080c125164fc878645c74 Mon Sep 17 00:00:00 2001
+From: Marius Ungureanu <marius.ungureanu@xamarin.com>
+Date: Fri, 25 Jun 2021 13:57:46 +0300
+Subject: [PATCH 25/32] [2020-02] Fix memory leak during data registration
+ (#21107) (#21116)
+
+Co-authored-by: Fan Yang <52458914+fanyang-mono@users.noreply.github.com>
+---
+ mono/mini/mini-generic-sharing.c | 30 +++++++++++++++++++++++++++---
+ 1 file changed, 27 insertions(+), 3 deletions(-)
+
+diff --git a/mono/mini/mini-generic-sharing.c b/mono/mini/mini-generic-sharing.c
+index 45528b9cb45..90b19017a5b 100644
+--- a/mono/mini/mini-generic-sharing.c
++++ b/mono/mini/mini-generic-sharing.c
+@@ -2758,6 +2758,7 @@ mini_rgctx_info_type_to_patch_info_type (MonoRgctxInfoType info_type)
+  * @method: a method
+  * @in_mrgctx: whether to put the data into the MRGCTX
+  * @data: the info data
++ * @did_register: whether data was registered
+  * @info_type: the type of info to register about data
+  * @generic_context: a generic context
+  *
+@@ -2766,7 +2767,7 @@ mini_rgctx_info_type_to_patch_info_type (MonoRgctxInfoType info_type)
+  * encoded slot number.
+  */
+ static guint32
+-lookup_or_register_info (MonoClass *klass, MonoMethod *method, gboolean in_mrgctx, gpointer data,
++lookup_or_register_info (MonoClass *klass, MonoMethod *method, gboolean in_mrgctx, gpointer data, gboolean *did_register,
+ 						 MonoRgctxInfoType info_type, MonoGenericContext *generic_context)
+ {
+ 	int type_argc = 0;
+@@ -2815,7 +2816,10 @@ lookup_or_register_info (MonoClass *klass, MonoMethod *method, gboolean in_mrgct
+ 
+ 	/* We haven't found the info */
+ 	if (index == -1)
++	{
+ 		index = register_info (klass, type_argc, data, info_type);
++		*did_register = TRUE;
++	}
+ 
+ 	/* interlocked by loader lock */
+ 	if (index > UnlockedRead (&rgctx_max_slot_number))
+@@ -4145,6 +4149,8 @@ int
+ mini_get_rgctx_entry_slot (MonoJumpInfoRgctxEntry *entry)
+ {
+ 	gpointer entry_data = NULL;
++	gboolean did_register = FALSE;
++	guint32 result = -1;
+ 
+ 	switch (entry->data->type) {
+ 	case MONO_PATCH_INFO_CLASS:
+@@ -4211,9 +4217,27 @@ mini_get_rgctx_entry_slot (MonoJumpInfoRgctxEntry *entry)
+ 	}
+ 
+ 	if (entry->in_mrgctx)
+-		return lookup_or_register_info (entry->d.method->klass, entry->d.method, entry->in_mrgctx, entry_data, entry->info_type, mono_method_get_context (entry->d.method));
++		result = lookup_or_register_info (entry->d.method->klass, entry->d.method, entry->in_mrgctx, entry_data, &did_register, entry->info_type, mono_method_get_context (entry->d.method));
+ 	else
+-		return lookup_or_register_info (entry->d.klass, NULL, entry->in_mrgctx, entry_data, entry->info_type, mono_class_get_context (entry->d.klass));
++		result = lookup_or_register_info (entry->d.klass, NULL, entry->in_mrgctx, entry_data, &did_register, entry->info_type, mono_class_get_context (entry->d.klass));
++
++	if (!did_register)
++		switch (entry->data->type) {
++		case MONO_PATCH_INFO_GSHAREDVT_CALL:
++		case MONO_PATCH_INFO_VIRT_METHOD:
++		case MONO_PATCH_INFO_DELEGATE_TRAMPOLINE:
++			g_free (entry_data);
++			break;
++		case MONO_PATCH_INFO_GSHAREDVT_METHOD: {
++			g_free (((MonoGSharedVtMethodInfo *) entry_data)->entries);
++			g_free (entry_data);
++			break;
++		}
++		default :
++			break;
++		}
++
++	return result;
+ }
+ 
+ static gboolean gsharedvt_supported;
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154.inc
+++ b/recipes-mono/mono/mono-6.12.0.154.inc
@@ -1,0 +1,10 @@
+BASEPV = "6.12.0.122"
+SRC_URI[sha256sum] = "29c277660fc5e7513107aee1cbf8c5057c9370a4cdfeda2fc781be6986d89d23"
+
+S = "${WORKDIR}/mono-${BASEPV}"
+
+DEPENDS += " cmake-native"
+
+do_configure:prepend () {
+	sed -i 's/${BASEPV}/${PV}/g' configure.ac
+}

--- a/recipes-mono/mono/mono-6.12.0.154/0001-patch-XplatUIX11-cursor.diff
+++ b/recipes-mono/mono/mono-6.12.0.154/0001-patch-XplatUIX11-cursor.diff
@@ -1,0 +1,15 @@
+diff -ur mono-6.8.0.96.org/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs mono-6.8.0.96/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+--- mono-6.8.0.96.org/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs	2020-01-15 07:46:01.000000000 +0000
++++ mono-6.8.0.96/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs	2020-02-08 21:22:11.059830600 +0000
+@@ -3091,6 +3091,11 @@
+ 				return IntPtr.Zero;
+ 			}
+ 
++			if(width == 0 || height == 0) {
++                          width = bitmap.Width;
++                          height = bitmap.Height;
++                        }
++
+ 			// Win32 only allows creation cursors of a certain size
+ 			if ((bitmap.Width != width) || (bitmap.Width != height)) {
+ 				cursor_bitmap = new Bitmap(bitmap, new Size(width, height));

--- a/recipes-mono/mono/mono-6.12.0.154/0004-Disable-DebuggerTests.Crash-since-it-fails-on-Linux-.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0004-Disable-DebuggerTests.Crash-since-it-fails-on-Linux-.patch
@@ -1,0 +1,28 @@
+From fdf57e77442b94c38ac1d4f33e8be752351a8db5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexander=20K=C3=B6plinger?= <alex.koeplinger@outlook.com>
+Date: Mon, 8 Mar 2021 11:45:16 +0100
+Subject: [PATCH 04/32] Disable DebuggerTests.Crash since it fails on Linux
+ i386 in CI
+
+See https://github.com/mono/mono/issues/20905
+
+(cherry picked from commit 7eb63051a8b49d9174dd65a319b6b08f98385ad9)
+---
+ mcs/class/Mono.Debugger.Soft/Test/dtest.cs | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+index 8c953f6fe3d..0fbe87421db 100644
+--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
++++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+@@ -2475,6 +2475,7 @@ Event step_out_await (string method, Event e)
+ 	[Test]
+ 	[Category("NotOnWindows")]
+ 	[Category ("AndroidSdksNotWorking")]
++	[Ignore("https://github.com/mono/mono/issues/20905")] // fails on Linux i386 on CI
+ 	public void Crash () {
+ 		string [] existingCrashFileEntries = Directory.GetFiles (".", "mono_crash*.json");
+ 
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0007-Don-t-include-mono-dtrace.h-when-generating-offsets.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0007-Don-t-include-mono-dtrace.h-when-generating-offsets.patch
@@ -1,0 +1,26 @@
+From be9218f4d1f7529fbe85d15c58f6fe78161909b3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexander=20K=C3=B6plinger?= <alex.koeplinger@outlook.com>
+Date: Wed, 10 Mar 2021 22:36:56 +0100
+Subject: [PATCH 07/32] Don't include mono-dtrace.h when generating offsets
+
+offsets-tool can run before mono-dtrace.h is generated which leads to a compiler error about the file missing.
+---
+ mono/utils/dtrace.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mono/utils/dtrace.h b/mono/utils/dtrace.h
+index 540f2588a8b..bd3062530ff 100644
+--- a/mono/utils/dtrace.h
++++ b/mono/utils/dtrace.h
+@@ -10,7 +10,7 @@
+ #ifndef __UTILS_DTRACE_H__
+ #define __UTILS_DTRACE_H__
+ 
+-#ifdef ENABLE_DTRACE
++#if defined(ENABLE_DTRACE) && !defined(MONO_GENERATING_OFFSETS)
+ 
+ #include <mono/utils/mono-dtrace.h>
+ 
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0008-2020-02-marshal-Fix-VARIANT-and-BSTR-marshaling-in-s.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0008-2020-02-marshal-Fix-VARIANT-and-BSTR-marshaling-in-s.patch
@@ -1,0 +1,251 @@
+From acb8d8ed6fd7fc7034b57157db1119bb5e259cc3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Aleksey=20Kliger=20=28=CE=BBgeek=29?= <alklig@microsoft.com>
+Date: Thu, 11 Mar 2021 12:38:52 -0500
+Subject: [PATCH 08/32] [2020-02][marshal] Fix VARIANT and BSTR marshaling in
+ structs (#20918)
+
+* [tests] Add BStr and VARIANT in structs interop tests
+
+* [marshal] Fix reverse P/Invoke marshaling VARIANT fields
+
+Partial revert of https://github.com/mono/mono/pull/8732
+
+If a managed struct is declared as
+
+        public struct StructWithVariant
+        {
+            [MarshalAs (UnmanagedType.Struct)]
+            public object data;
+        };
+
+Then the `data` field should be marshalled as a VARIANT.
+
+The fix checks that the field's type is `object` and uses VARIANT for
+marshaling, otherwise it continues as in mono/mono#8732 and uses
+MONO_MARSHAL_CONV_OBJECT_STRUCT
+
+* [marshal] Marshal BSTR from reverse pinvokes
+---
+ mono/metadata/marshal-ilgen.c |  8 ++++-
+ mono/metadata/metadata.c      | 12 ++++++-
+ mono/tests/cominterop.cs      | 65 +++++++++++++++++++++++++++++++++--
+ mono/tests/libtest.c          | 48 ++++++++++++++++++++++++++
+ 4 files changed, 129 insertions(+), 4 deletions(-)
+
+diff --git a/mono/metadata/marshal-ilgen.c b/mono/metadata/marshal-ilgen.c
+index 5472727ef0f..de6fefed06e 100644
+--- a/mono/metadata/marshal-ilgen.c
++++ b/mono/metadata/marshal-ilgen.c
+@@ -488,6 +488,13 @@ emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv
+ 		mono_mb_emit_icall (mb, ves_icall_mono_string_from_utf16);
+ 		mono_mb_emit_byte (mb, CEE_STIND_REF);
+ 		break;
++	case MONO_MARSHAL_CONV_STR_BSTR:
++		mono_mb_emit_ldloc (mb, 1);
++		mono_mb_emit_ldloc (mb, 0);
++		mono_mb_emit_byte (mb, CEE_LDIND_I);
++		mono_mb_emit_icall (mb, mono_string_from_bstr_icall);
++		mono_mb_emit_byte (mb, CEE_STIND_REF);
++		break;
+ 	case MONO_MARSHAL_CONV_OBJECT_STRUCT: {
+ 		MonoClass *klass = mono_class_from_mono_type_internal (type);
+ 		int src_var, dst_var;
+@@ -576,7 +583,6 @@ emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv
+ 		break;
+ 	}
+ 		
+-	case MONO_MARSHAL_CONV_STR_BSTR:
+ 	case MONO_MARSHAL_CONV_STR_ANSIBSTR:
+ 	case MONO_MARSHAL_CONV_STR_TBSTR:
+ 	case MONO_MARSHAL_CONV_ARRAY_SAVEARRAY:
+diff --git a/mono/metadata/metadata.c b/mono/metadata/metadata.c
+index 5f6568da9b0..b2987016ef2 100644
+--- a/mono/metadata/metadata.c
++++ b/mono/metadata/metadata.c
+@@ -6781,7 +6781,17 @@ handle_enum:
+ 		if (mspec) {
+ 			switch (mspec->native) {
+ 			case MONO_NATIVE_STRUCT:
+-				*conv = MONO_MARSHAL_CONV_OBJECT_STRUCT;
++				// [MarshalAs(UnmanagedType.Struct)]
++				// object field;
++				//
++				// becomes a VARIANT
++				//
++				// [MarshalAs(UnmangedType.Struct)]
++				// SomeClass field;
++				//
++				// becomes uses the CONV_OBJECT_STRUCT conversion
++				if (t != MONO_TYPE_OBJECT)
++					*conv = MONO_MARSHAL_CONV_OBJECT_STRUCT;
+ 				return MONO_NATIVE_STRUCT;
+ 			case MONO_NATIVE_CUSTOM:
+ 				return MONO_NATIVE_CUSTOM;
+diff --git a/mono/tests/cominterop.cs b/mono/tests/cominterop.cs
+index e83cafd0625..11cb68bcdbc 100644
+--- a/mono/tests/cominterop.cs
++++ b/mono/tests/cominterop.cs
+@@ -224,7 +224,21 @@ public class Tests
+ 	[DllImport ("libtest")]
+ 	public static extern int mono_test_marshal_variant_out_bool_false_unmanaged (VarRefFunc func);
+ 
+-    [DllImport ("libtest")]
++	public delegate int CheckStructWithVariantFunc ([MarshalAs (UnmanagedType.Struct)] StructWithVariant obj);
++	[DllImport ("libtest")]
++	public static extern int mono_test_marshal_struct_with_variant_in_unmanaged (CheckStructWithVariantFunc func);
++
++	public delegate int CheckStructWithBstrFunc ([MarshalAs (UnmanagedType.Struct)] StructWithBstr obj);
++	[DllImport ("libtest")]
++	public static extern int mono_test_marshal_struct_with_bstr_in_unmanaged (CheckStructWithBstrFunc func);
++
++	[DllImport ("libtest")]
++	public static extern int mono_test_marshal_struct_with_variant_out_unmanaged ([MarshalAs (UnmanagedType.Struct)] StructWithVariant obj);
++
++	[DllImport ("libtest")]
++	public static extern int mono_test_marshal_struct_with_bstr_out_unmanaged ([MarshalAs (UnmanagedType.Struct)] StructWithBstr obj);
++
++	[DllImport ("libtest")]
+ 	public static extern int mono_test_marshal_com_object_create (out IntPtr pUnk);
+ 
+ 	[DllImport ("libtest")]
+@@ -338,7 +352,6 @@ public class Tests
+ 
+ 	public static int Main ()
+ 	{
+-
+ 		bool isWindows = !(((int)Environment.OSVersion.Platform == 4) ||
+ 			((int)Environment.OSVersion.Platform == 128));
+ 
+@@ -356,6 +369,15 @@ public static int Main ()
+ 			if (mono_test_marshal_bstr_out_null (out str) != 0 || str != null)
+ 				return 2;
+ 
++			var sbfunc = new CheckStructWithBstrFunc(mono_test_marshal_struct_with_bstr_callback);
++			if (mono_test_marshal_struct_with_bstr_in_unmanaged(sbfunc) != 0)
++				return 3;
++
++			StructWithBstr swithB;
++			swithB.data = "this is a test string";
++			if (mono_test_marshal_struct_with_bstr_out_unmanaged (swithB) != 0)
++				return 4;
++
+ 			#endregion // BSTR Tests
+ 
+ 			#region VARIANT Tests
+@@ -481,6 +503,15 @@ public static int Main ()
+ 			if (mono_test_marshal_variant_out_bstr_byref (out obj) != 0 || (string)obj != "PI")
+ 				return 107;
+ 
++			var svfunc = new CheckStructWithVariantFunc(mono_test_marshal_struct_with_variant_callback);
++			if (mono_test_marshal_struct_with_variant_in_unmanaged(svfunc) != 0)
++				return 108;
++
++			StructWithVariant swithV;
++			swithV.data = (object)-123;
++			if (mono_test_marshal_struct_with_variant_out_unmanaged (swithV) != 0)
++				return 109;
++
+ 			#endregion // VARIANT Tests
+ 
+ 			#region Runtime Callable Wrapper Tests
+@@ -1581,8 +1612,38 @@ public static int TestITestDelegate (ITest itest)
+ 	public static int TestIfaceNoIcall (ITestPresSig itest) {
+ 		return itest.Return22NoICall () == 22 ? 0 : 1;
+ 	}
++
++        public static int mono_test_marshal_struct_with_variant_callback(StructWithVariant sv)
++        {
++            if (sv.data.GetType() != typeof(int))
++                return 1;
++            if ((int)sv.data != -123)
++                return 2;
++            return 0;
++        }
++
++        public static int mono_test_marshal_struct_with_bstr_callback(StructWithBstr sb)
++        {
++            if (sb.data.GetType() != typeof(string))
++                return 1;
++            if ((string)sb.data != "this is a test string")
++                return 2;
++            return 0;
++        }
+ }
+ 
+ public class TestVisible
+ {
+ }
++
++public struct StructWithVariant
++{
++	[MarshalAs (UnmanagedType.Struct)]
++	public object data;
++}
++
++public struct StructWithBstr
++{
++	[MarshalAs (UnmanagedType.BStr)]
++	public string data;
++}
+diff --git a/mono/tests/libtest.c b/mono/tests/libtest.c
+index 3f14636bb25..e5e5f2f14d3 100644
+--- a/mono/tests/libtest.c
++++ b/mono/tests/libtest.c
+@@ -3378,6 +3378,54 @@ mono_test_marshal_variant_out_bool_false_unmanaged(VarRefFunc func)
+ 	return 1;
+ }
+ 
++typedef struct _StructWithVariant {
++    VARIANT data;
++} StructWithVariant;
++typedef int (STDCALL *CheckStructWithVariantFunc) (StructWithVariant sv);
++
++LIBTEST_API int STDCALL 
++mono_test_marshal_struct_with_variant_in_unmanaged(CheckStructWithVariantFunc func)
++{
++    StructWithVariant sv;
++    sv.data.vt = VT_I4;
++    sv.data.lVal = -123;
++    return func(sv);
++}
++
++LIBTEST_API int STDCALL
++mono_test_marshal_struct_with_variant_out_unmanaged (StructWithVariant sv)
++{
++	if (sv.data.vt != VT_I4)
++		return 1;
++	if (sv.data.lVal != -123)
++		return 2;
++	return 0;
++}
++
++typedef struct _StructWithBstr {
++    gunichar2* data;
++} StructWithBstr;
++typedef int (STDCALL *CheckStructWithBstrFunc) (StructWithBstr sb);
++
++LIBTEST_API int STDCALL 
++mono_test_marshal_struct_with_bstr_in_unmanaged(CheckStructWithBstrFunc func)
++{
++    StructWithBstr sb;
++    sb.data = marshal_bstr_alloc("this is a test string");
++    return func(sb);
++}
++
++LIBTEST_API int STDCALL
++mono_test_marshal_struct_with_bstr_out_unmanaged (StructWithBstr sb)
++{
++	char *s = g_utf16_to_utf8 (sb.data, g_utf16_len (sb.data), NULL, NULL, NULL);
++	gboolean same = !strcmp (s, "this is a test string");
++	g_free (s);
++	if (!same)
++		return 1;
++	return 0;
++}
++
+ typedef struct MonoComObject MonoComObject;
+ typedef struct MonoDefItfObject MonoDefItfObject;
+ 
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0010-Fix-the-System.String.Replace-throwing-NotImplemente.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0010-Fix-the-System.String.Replace-throwing-NotImplemente.patch
@@ -1,0 +1,43 @@
+From 69cfb5fa61ab9b78c7c4f76812b8b84f165dc73d Mon Sep 17 00:00:00 2001
+From: Maxim Lipnin <v-maxlip@microsoft.com>
+Date: Sat, 27 Mar 2021 13:39:33 +0300
+Subject: [PATCH 10/32] Fix the System.String.Replace throwing
+ NotImplementedException (#20960) (#20978)
+
+https://github.com/mono/mono/issues/20948
+---
+ mcs/class/corlib/Test/System/StringTest.cs | 4 ++++
+ mcs/class/corlib/corefx/CompareInfo.cs     | 2 +-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/mcs/class/corlib/Test/System/StringTest.cs b/mcs/class/corlib/Test/System/StringTest.cs
+index eabaa07fe12..4407d4a71a7 100644
+--- a/mcs/class/corlib/Test/System/StringTest.cs
++++ b/mcs/class/corlib/Test/System/StringTest.cs
+@@ -3221,6 +3221,10 @@ public void Replace()
+ 
+ 		// Test replacing null characters (bug #67395)
+ 		Assert.AreEqual ("is this ok ?", "is \0 ok ?".Replace ("\0", "this"), "should not strip content after nullchar");
++
++		// System.String.Replace fails with NotImplementedException https://github.com/mono/mono/issues/20948
++		Assert.AreEqual ("Original", s1.Replace("o", "O", StringComparison.CurrentCulture), "Replace(string, string, StringComparison)");
++		Assert.AreEqual ("Original", s1.Replace("o", "O", false, CultureInfo.CurrentCulture), "Replace(string, string, bool, CultureInfo)");
+ 	}
+ 
+ 	[Test]
+diff --git a/mcs/class/corlib/corefx/CompareInfo.cs b/mcs/class/corlib/corefx/CompareInfo.cs
+index b8205f21ac5..08f6aa50355 100644
+--- a/mcs/class/corlib/corefx/CompareInfo.cs
++++ b/mcs/class/corlib/corefx/CompareInfo.cs
+@@ -86,7 +86,7 @@ int LastIndexOfCore (string source, string target, int startIndex, int count, Co
+ 		unsafe int IndexOfCore (string source, string target, int startIndex, int count, CompareOptions options, int* matchLengthPtr)
+ 		{
+ 			if (matchLengthPtr != null)
+-				throw new NotImplementedException ();
++				*matchLengthPtr = target.Length;
+ 
+ 			return internal_index_switch (source, startIndex, count, target, options, true);
+ 		}
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0014-2020-02-Backport-r4-conv-i-fixes-20986.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0014-2020-02-Backport-r4-conv-i-fixes-20986.patch
@@ -1,0 +1,85 @@
+From 225ba3c8cb1a309513222a513db0b092bdfab2aa Mon Sep 17 00:00:00 2001
+From: Vlad Brezae <brezaevlad@gmail.com>
+Date: Tue, 30 Mar 2021 17:08:00 +0300
+Subject: [PATCH 14/32] [2020-02] Backport r4-conv-i fixes (#20986)
+
+* [mini] Add missing opcodes for r4 to native int conversions
+
+* [interp] Add handling for conv.i from r4
+---
+ mono/mini/cpu-arm.md         | 1 +
+ mono/mini/cpu-arm64.md       | 1 +
+ mono/mini/interp/transform.c | 7 +++++++
+ mono/mini/mini-arm.c         | 1 +
+ mono/mini/mini-arm64.c       | 1 +
+ 5 files changed, 11 insertions(+)
+
+diff --git a/mono/mini/cpu-arm.md b/mono/mini/cpu-arm.md
+index f3b6641d3f5..516bbb3209d 100644
+--- a/mono/mini/cpu-arm.md
++++ b/mono/mini/cpu-arm.md
+@@ -227,6 +227,7 @@ rmove: dest:f src1:f len:4
+ r4_conv_to_i1: dest:i src1:f len:88
+ r4_conv_to_i2: dest:i src1:f len:88
+ r4_conv_to_i4: dest:i src1:f len:88
++r4_conv_to_i: dest:i src1:f len:88
+ r4_conv_to_u1: dest:i src1:f len:88
+ r4_conv_to_u2: dest:i src1:f len:88
+ r4_conv_to_u4: dest:i src1:f len:88
+diff --git a/mono/mini/cpu-arm64.md b/mono/mini/cpu-arm64.md
+index 6b8488c0468..aff89052937 100644
+--- a/mono/mini/cpu-arm64.md
++++ b/mono/mini/cpu-arm64.md
+@@ -229,6 +229,7 @@ r4_conv_to_u2: dest:i src1:f len:8
+ r4_conv_to_i4: dest:i src1:f len:8
+ r4_conv_to_u4: dest:i src1:f len:8
+ r4_conv_to_i8: dest:l src1:f len:8
++r4_conv_to_i: dest:l src1:f len:8
+ r4_conv_to_u8: dest:l src1:f len:8
+ r4_conv_to_r4: dest:f src1:f len:4
+ r4_conv_to_r8: dest:f src1:f len:4
+diff --git a/mono/mini/interp/transform.c b/mono/mini/interp/transform.c
+index 7438255c6a1..60cfb37c5a2 100644
+--- a/mono/mini/interp/transform.c
++++ b/mono/mini/interp/transform.c
+@@ -4201,6 +4201,13 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header,
+ 				interp_add_ins (td, MINT_CONV_I8_R8);
+ #else
+ 				interp_add_ins (td, MINT_CONV_I4_R8);
++#endif
++				break;
++			case STACK_TYPE_R4:
++#if SIZEOF_VOID_P == 8
++				interp_add_ins (td, MINT_CONV_I8_R4);
++#else
++				interp_add_ins (td, MINT_CONV_I4_R4);
+ #endif
+ 				break;
+ 			case STACK_TYPE_I4:
+diff --git a/mono/mini/mini-arm.c b/mono/mini/mini-arm.c
+index 00c0be5fdfe..678b4a2f77a 100644
+--- a/mono/mini/mini-arm.c
++++ b/mono/mini/mini-arm.c
+@@ -5909,6 +5909,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
+ 			code = emit_r4_to_int (cfg, code, ins->dreg, ins->sreg1, 2, FALSE);
+ 			break;
+ 		case OP_RCONV_TO_I4:
++		case OP_RCONV_TO_I:
+ 			code = emit_r4_to_int (cfg, code, ins->dreg, ins->sreg1, 4, TRUE);
+ 			break;
+ 		case OP_RCONV_TO_U4:
+diff --git a/mono/mini/mini-arm64.c b/mono/mini/mini-arm64.c
+index 2dc1a5532ef..4e3688c87d4 100644
+--- a/mono/mini/mini-arm64.c
++++ b/mono/mini/mini-arm64.c
+@@ -4304,6 +4304,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
+ 			arm_fcvtzu_sx (code, dreg, sreg1);
+ 			break;
+ 		case OP_RCONV_TO_I8:
++		case OP_RCONV_TO_I:
+ 			arm_fcvtzs_sx (code, dreg, sreg1);
+ 			break;
+ 		case OP_RCONV_TO_U8:
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0016-arm64-Fix-wrong-marshalling-in-gsharedvt-transition-.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0016-arm64-Fix-wrong-marshalling-in-gsharedvt-transition-.patch
@@ -1,0 +1,36 @@
+From c90ec48f596c5d18c07724c749fa13c5ad07161d Mon Sep 17 00:00:00 2001
+From: Vlad Brezae <brezaevlad@gmail.com>
+Date: Tue, 13 Apr 2021 20:13:30 +0300
+Subject: [PATCH 16/32] [arm64] Fix wrong marshalling in gsharedvt transition
+ (#21006)
+
+Transitioning from ArgVtypeByRefOnStack to ArgVtypeByRef requires no marshalling. The reference ends up being saved on stack the same way and the stack slot just needs to be copied (in mono_arm_start_gsharedvt_call).
+---
+ mono/mini/mini-arm64-gsharedvt.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/mono/mini/mini-arm64-gsharedvt.c b/mono/mini/mini-arm64-gsharedvt.c
+index 67689024464..f3a0653a03a 100644
+--- a/mono/mini/mini-arm64-gsharedvt.c
++++ b/mono/mini/mini-arm64-gsharedvt.c
+@@ -229,7 +229,7 @@ mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_si
+ 		}
+ 		if (ainfo2->storage == ArgVtypeByRef && ainfo2->gsharedvt) {
+ 			/* Pass the address of the first src slot in a reg */
+-			if (ainfo->storage != ArgVtypeByRef) {
++			if (ainfo->storage != ArgVtypeByRef && ainfo->storage != ArgVtypeByRefOnStack) {
+ 				if (ainfo->storage == ArgHFA && ainfo->esize == 4) {
+ 					arg_marshal = GSHAREDVT_ARG_BYVAL_TO_BYREF_HFAR4;
+ 					g_assert (src [0] < 64);
+@@ -244,7 +244,7 @@ mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_si
+ 			dst [0] = map_reg (ainfo2->reg);
+ 		} else if (ainfo2->storage == ArgVtypeByRefOnStack && ainfo2->gsharedvt) {
+ 			/* Pass the address of the first src slot in a stack slot */
+-			if (ainfo->storage != ArgVtypeByRef)
++			if (ainfo->storage != ArgVtypeByRef && ainfo->storage != ArgVtypeByRefOnStack)
+ 				arg_marshal = GSHAREDVT_ARG_BYVAL_TO_BYREF;
+ 			ndst = 1;
+ 			dst = g_new0 (int, 1);
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0019-MonoIO-Wrap-calls-to-open-in-EINTR-handling-21042.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0019-MonoIO-Wrap-calls-to-open-in-EINTR-handling-21042.patch
@@ -1,0 +1,64 @@
+From 0449008883dfe8cf108c74ba1167f99723d5a3a3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Aleksey=20Kliger=20=28=CE=BBgeek=29?= <alklig@microsoft.com>
+Date: Fri, 30 Apr 2021 13:09:56 -0400
+Subject: [PATCH 19/32] [MonoIO] Wrap calls to open() in EINTR handling
+ (#21042)
+
+Related to https://github.com/mono/mono/issues/21040 and
+https://github.com/dotnet/runtime/issues/48663
+
+On MacOS Big Sur open() is much more likely to throw EINTR - and moreover if
+the thread receives a signal while doing an open() even if the signal handler
+is marked with SA_RESTART, the open call appears not to restart and to fail
+anyway.
+
+So wrap all the calls to open() in retry loops.
+---
+ mono/metadata/w32file-unix.c | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/mono/metadata/w32file-unix.c b/mono/metadata/w32file-unix.c
+index 819bbba6818..5430744f9d1 100644
+--- a/mono/metadata/w32file-unix.c
++++ b/mono/metadata/w32file-unix.c
+@@ -282,17 +282,23 @@ _wapi_open (const gchar *pathname, gint flags, mode_t mode)
+ 		located_filename = mono_portability_find_file (pathname, FALSE);
+ 		if (located_filename == NULL) {
+ 			MONO_ENTER_GC_SAFE;
+-			fd = open (pathname, flags, mode);
++			do {
++				fd = open (pathname, flags, mode);
++			} while (fd == -1 && errno == EINTR);
+ 			MONO_EXIT_GC_SAFE;
+ 		} else {
+ 			MONO_ENTER_GC_SAFE;
+-			fd = open (located_filename, flags, mode);
++			do {
++				fd = open (located_filename, flags, mode);
++			} while (fd == -1 && errno == EINTR);
+ 			MONO_EXIT_GC_SAFE;
+ 			g_free (located_filename);
+ 		}
+ 	} else {
+ 		MONO_ENTER_GC_SAFE;
+-		fd = open (pathname, flags, mode);
++		do {
++			fd = open (pathname, flags, mode);
++		} while (fd == -1 && errno == EINTR);
+ 		MONO_EXIT_GC_SAFE;
+ 		if (fd == -1 && (errno == ENOENT || errno == ENOTDIR) && IS_PORTABILITY_SET) {
+ 			gint saved_errno = errno;
+@@ -304,7 +310,9 @@ _wapi_open (const gchar *pathname, gint flags, mode_t mode)
+ 			}
+ 
+ 			MONO_ENTER_GC_SAFE;
+-			fd = open (located_filename, flags, mode);
++			do {
++				fd = open (located_filename, flags, mode);
++			} while (fd == -1 && errno == EINTR);
+ 			MONO_EXIT_GC_SAFE;
+ 			g_free (located_filename);
+ 		}
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0020-2020-02-Fix-leak-in-assembly-specific-dllmap-lookups.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0020-2020-02-Fix-leak-in-assembly-specific-dllmap-lookups.patch
@@ -1,0 +1,80 @@
+From 28a101a8ab5a3852bcb8876edfbc9d9f1360cd35 Mon Sep 17 00:00:00 2001
+From: Ryan Lucia <rylucia@microsoft.com>
+Date: Mon, 10 May 2021 09:30:00 -0400
+Subject: [PATCH 20/32] [2020-02] Fix leak in assembly-specific dllmap lookups
+ (#21053)
+
+---
+ mono/metadata/native-library.c | 18 ++++++++++--------
+ 1 file changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/mono/metadata/native-library.c b/mono/metadata/native-library.c
+index d57252f1b1d..0f556794a38 100644
+--- a/mono/metadata/native-library.c
++++ b/mono/metadata/native-library.c
+@@ -83,9 +83,9 @@ GENERATE_GET_CLASS_WITH_CACHE (native_library, "System.Runtime.InteropServices",
+  * LOCKING: Assumes the relevant lock is held.
+  * For the global DllMap, this is `global_loader_data_mutex`, and for images it's their internal lock.
+  */
+-static int
++static gboolean
+ mono_dllmap_lookup_list (MonoDllMap *dll_map, const char *dll, const char* func, const char **rdll, const char **rfunc) {
+-	int found = 0;
++	gboolean found = FALSE;
+ 
+ 	*rdll = dll;
+ 	*rfunc = func;
+@@ -107,7 +107,7 @@ mono_dllmap_lookup_list (MonoDllMap *dll_map, const char *dll, const char* func,
+ 
+ 		if (!found && dll_map->target) {
+ 			*rdll = dll_map->target;
+-			found = 1;
++			found = TRUE;
+ 			/* we don't quit here, because we could find a full
+ 			 * entry that also matches the function, which takes priority.
+ 			 */
+@@ -120,8 +120,6 @@ mono_dllmap_lookup_list (MonoDllMap *dll_map, const char *dll, const char* func,
+ 	}
+ 
+ exit:
+-	*rdll = g_strdup (*rdll);
+-	*rfunc = g_strdup (*rfunc);
+ 	return found;
+ }
+ 
+@@ -129,10 +127,10 @@ exit:
+  * The locking and GC state transitions here are wonky due to the fact the image lock is a coop lock
+  * and the global loader data lock is an OS lock.
+  */
+-static int
++static gboolean
+ mono_dllmap_lookup (MonoImage *assembly, const char *dll, const char* func, const char **rdll, const char **rfunc)
+ {
+-	int res;
++	gboolean res;
+ 
+ 	MONO_REQ_GC_UNSAFE_MODE;
+ 
+@@ -141,7 +139,7 @@ mono_dllmap_lookup (MonoImage *assembly, const char *dll, const char* func, cons
+ 		res = mono_dllmap_lookup_list (assembly->dll_map, dll, func, rdll, rfunc);
+ 		mono_image_unlock (assembly);
+ 		if (res)
+-			return res;
++			goto leave;
+ 	}
+ 
+ 	MONO_ENTER_GC_SAFE;
+@@ -152,6 +150,10 @@ mono_dllmap_lookup (MonoImage *assembly, const char *dll, const char* func, cons
+ 
+ 	MONO_EXIT_GC_SAFE;
+ 
++leave:
++	*rdll = g_strdup (*rdll);
++	*rfunc = g_strdup (*rfunc);
++
+ 	return res;
+ }
+ 
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0024-2020-02-Start-a-dedicated-thread-for-MERP-crash-repo.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0024-2020-02-Start-a-dedicated-thread-for-MERP-crash-repo.patch
@@ -1,0 +1,908 @@
+From 63035635944865e83afee8efd6c346af1c077d58 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Aleksey=20Kliger=20=28=CE=BBgeek=29?= <alklig@microsoft.com>
+Date: Wed, 23 Jun 2021 20:18:19 -0400
+Subject: [PATCH 24/32] [2020-02] Start a dedicated thread for MERP crash
+ reporting (#21126)
+
+Related to #21009.
+
+There are two scenarios:
+1.  When someone force quits Mono (or just runs `kill -TERM <pid>`), the process can receive the signal on any thread,
+2. or - if a thread in the process crashes, but the thread is not attached to the runtime, Mono's signal handlers still run.
+
+The crash reporter assumes that the crashing thread is either attached to the runtime, or at least `mono_thread_info_current` or the JIT TLS data are set for the thread.  If the thread is truly foreign and it never interacted with Mono, and it crashes, both of those assumptions are false, but Mono's crash reporter signal handlers still run.
+
+The solution from this PR is: if crash reporting is enabled, start a dedicated thread at process startup that is a "crash report leader" - when a crash happens, the crashing thread (the crash originator) wakes the leader, and the leader collects the crash report.  The crash originator does not do any work that requires being attached to the runtime or to the JIT such as iterating over thread IDs or stack walking.
+
+
+---
+
+* Add a standalone test of crash on a foreign thread
+
+* Sketch out crash leader implementation
+
+   At process startup, start a separate thread that is attached to the runtime and can collect crash reports.  Crashing threads will wake it and wait for it to collect the crash reports
+
+* Start moving responsibilities to the crash leader
+
+* Watch for nil jit_tls data if crash is on a foreign thread
+
+* Start adding a state machine for the crash leader
+
+   We need to coordinate the originator and the leader in a few places.
+
+   The leader needs to pause to after collecting the thread ids before suspending the non-originator threads, and again while the originator is dumping its own stack.
+
+   The originator needs to wait for the leader to collect the thread IDs and to tell it its assigned slot. Then it tells the leader to suspend the others, dumps its own memory, then tell the leader to dump the whole crash report and wait for it to reply when it's done.
+
+* Move remaining summarizer work to the summarizer leader thread
+
+* change some debug printfs
+
+* Successfully summarize a foreign thread crash
+
+* Add test to merp-crash-test.cs
+
+* delete standalone test
+
+* if the crash leader is the originator, collect the report synchronously
+
+   either because the crash leader crashed, or because the process got a SIGTERM and it arrived on the crash leader thread
+
+* fixup comments
+
+* turn off crash leader printf debugging
+
+* Don't create leader thread if crash reporting is disabled
+
+* Fix test on win32
+
+* Update mono/tests/libtest.c
+
+* fixup logging and comments around managed stack collection
+
+* Disable the merp dlopen crasher
+
+* Remove crash leader state machine
+
+   It's straightline code with two early exits. State machine is overkill
+
+* remove remnants of leader state machine
+---
+ mono/metadata/appdomain.c     |   5 +
+ mono/metadata/threads-types.h |   5 +
+ mono/metadata/threads.c       | 490 ++++++++++++++++++++++++++++++++--
+ mono/mini/debugger-agent.c    |   4 +
+ mono/mini/mini-exceptions.c   |  13 +-
+ mono/mini/mini-runtime.c      |   2 +
+ mono/tests/libtest.c          |  28 ++
+ mono/tests/merp-crash-test.cs |  12 +-
+ mono/utils/hazard-pointer.c   |   2 +-
+ 9 files changed, 530 insertions(+), 31 deletions(-)
+
+diff --git a/mono/metadata/appdomain.c b/mono/metadata/appdomain.c
+index 724f4ea9a6b..95f3dcabc09 100644
+--- a/mono/metadata/appdomain.c
++++ b/mono/metadata/appdomain.c
+@@ -345,6 +345,11 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
+ 
+ 	mono_thread_attach (domain);
+ 
++#ifndef DISABLE_CRASH_REPORTING
++	if (!mono_runtime_get_no_exec ()) 
++		mono_summarizer_create_leader_thread ();
++#endif
++	
+ 	mono_type_initialization_init ();
+ 
+ 	if (!mono_runtime_get_no_exec ())
+diff --git a/mono/metadata/threads-types.h b/mono/metadata/threads-types.h
+index dc06fb56538..8a0fa9de244 100644
+--- a/mono/metadata/threads-types.h
++++ b/mono/metadata/threads-types.h
+@@ -569,4 +569,9 @@ mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *ha
+ gboolean
+ mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx);
+ 
++#ifndef DISABLE_CRASH_REPORTING
++void
++mono_summarizer_create_leader_thread (void);
++#endif
++
+ #endif /* _MONO_METADATA_THREADS_TYPES_H_ */
+diff --git a/mono/metadata/threads.c b/mono/metadata/threads.c
+index 5354a51b9e7..2cafb71bba5 100644
+--- a/mono/metadata/threads.c
++++ b/mono/metadata/threads.c
+@@ -6351,6 +6351,302 @@ summarizer_supervisor_end (SummarizerSupervisorState *state)
+ }
+ #endif
+ 
++/**
++ *
++ * Why a summarizer leader thread?
++ *
++ * The issue is that we set up signal handlers globally for all sorts of
++ * process-wide problems: sigsegv, sigterm, etc.  Which means that if a thread
++ * is created outside of the control of Mono, our signal handlers may still run
++ * on those threads.  But one of the things we need to do is interact with our
++ * thread state machinery, enumerate managed threads, etc - things that are
++ * generally not possible to do from an unattached thread.  We have a choice:
++ * we can either attach in the signal handler or we can punt the crash data
++ * collection to a thread that we know is already running and is in a healthy
++ * state.  Attaching in a signal handler is unlikely to work (attaching is not
++ * async signal safe).  So instead we initialize a crash report leader thread
++ * at startup, and ask it to collect the crash report on our behalf.
++ * 
++ *
++ * The order of operations is:
++ * - at startup:
++ *   - main thread starts leader thread
++ *   - leader thread starts, toggles leader_running and waits for begin_crash_report
++ * - to report a crash:
++ *   - mono_threads_summarize gates the crashes so only one thread originates a crash report at a time
++ *   - originating thread writes its info to the leader and posts to begin_crash_report.
++ *   - leader wakes up, copies the originator data, starts collecting a crash report
++ *   - leader and originator coordinate via leader_commanded and the response_fds to collect a crash report
++ *   - orignator returns to mono_threads_summarize, unblocks the next crash originator, if any, and then returns (which sends off the crash report in some way).
++ */
++
++typedef struct _MonoSummarizerOriginator {
++	/* in data */
++	SummarizerGlobalState *state;
++	MonoNativeThreadId originator_tid;
++	MonoContext *originator_ctx;
++	gchar *working_mem; /* in-data: memory for the summary report and its size */
++	size_t provided_size;
++	gchar **out; /* pointer into working_mem containing the output string */
++	/* in data - set after the originator dumps itself, while leader is waiting for all threads */
++	MonoThreadSummary *originator_summary;
++	/* out data */
++	/* index of originator thread in list of threads collected by the leader */
++	int originator_index;
++} MonoSummarizerOriginator;
++
++
++typedef struct _MonoSummarizerLeader {
++	MonoNativeThreadId leader_tid;
++	int32_t leader_running; /* only atomic reads */
++	MonoSemType begin_crash_report;
++	/* originator cant post commands to the leader */
++	MonoSemType leader_commanded;
++	int leader_command;
++	/* pipe to communicate back from the summarizer leader to the originator */
++	int response_fds[2];
++	/* Only one orignator at a time, gated by mono_threads_summarize tickets */
++	MonoSummarizerOriginator originator;
++} MonoSummarizerLeader;
++
++static MonoSummarizerLeader summarizer_leader_data;
++
++/* Commands from crash originator to the crash leader */
++enum LeaderCommand {
++	LEADER_COMMAND_ZERO = 0, /* not used */
++	LEADER_COMMAND_CANCEL = -1,
++	LEADER_COMMAND_PROCEED_TO_SUSPEND = 1,
++	LEADER_COMMAND_PROCEED_TO_TERM = 2,
++};
++
++/* Responses from the crash leader to the crash originator */
++enum LeaderResponse {
++	LEADER_RESPONSE_IDS_COLLECTED = 1,
++	LEADER_RESPONSE_THREADS_SUSPENDED = 2,
++	LEADER_RESPONSE_STACKS_WALKED = 3,
++};
++
++/* Uncomment to get additional debugging code in the crash leader */
++/* #define LEADER_DEBUG */
++
++#ifdef LEADER_DEBUG
++#define LEADER_LOG(...) g_async_safe_printf (__VA_ARGS__)
++#else
++#define LEADER_LOG(...) /*empty*/
++#endif
++
++/* Called by the leader to send responses to the originator */
++static void
++summarizer_leader_response_write (char b)
++{
++	int res;
++	LEADER_LOG ("leader --> originator: %d\n", (int)b);
++	while ((res = write (summarizer_leader_data.response_fds[1], &b, sizeof (b))) < 0 && errno == EINTR);
++}
++
++/* Called by the originator to receive (blocking) responses from the leader */
++static int
++summarizer_leader_response_read (void)
++{
++	char buf;
++	int nread = 0;
++	do {
++		int res = read(summarizer_leader_data.response_fds[0], &buf, sizeof (buf));
++		if (res < 0) {
++			if (errno == EINTR)
++				continue;
++			else
++				return -1;
++		}
++		nread += res;
++	} while (nread < sizeof (buf));
++	LEADER_LOG ("originator <---- leader : %d\n", (int)buf);
++	return (int)buf;
++}
++
++/* Called by the leader to wait for a command from the crash originator */
++static gboolean
++summarizer_leader_wait_for_command (int *leader_command)
++{
++	MONO_ENTER_GC_SAFE;
++	/* allow interruptions */
++	while (mono_os_sem_wait (&summarizer_leader_data.leader_commanded, MONO_SEM_FLAGS_ALERTABLE) < 0);
++	MONO_EXIT_GC_SAFE;
++	*leader_command = summarizer_leader_data.leader_command;
++	if (*leader_command == LEADER_COMMAND_CANCEL) {
++		return FALSE;
++	}
++	return TRUE;
++}
++
++
++/* Called by the originator to post commands to the leader.  Usually just to proceed to the next state */
++static void
++summarizer_leader_post_command (int command)
++{
++	summarizer_leader_data.leader_command = command;
++	mono_os_sem_post (&summarizer_leader_data.leader_commanded);
++}
++
++static void
++summarizer_leader_collect_thread_ids (SummarizerGlobalState *state);
++static void
++summarizer_leader_suspend_others (SummarizerGlobalState *state, MonoNativeThreadId originator, int originator_idx);
++static void
++summarizer_leader_set_originator_summary (MonoThreadSummary *orignator_summary);
++static void
++summarizer_state_get_index_for_thread (SummarizerGlobalState *state, MonoNativeThreadId current, int *my_index);
++static void
++summarizer_state_wait_and_term (MonoNativeThreadId caller_tid, SummarizerGlobalState *state, gchar **out, gchar *working_mem, size_t provided_size, MonoThreadSummary *originator_summary);
++static void
++summarizer_leader_adjust_tids_for_foreign_originator (void);
++
++static void
++summarizer_leader (void)
++{
++	MonoInternalThread *thread = mono_thread_internal_current ();
++	thread->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
++
++	/*
++	 * This thread must not be stopped by the profiler or the STW
++	 * machinery. While collecting crashes it also violates the coop GC
++	 * rules by accessing managed memory to gather crash reports.  But
++	 * crash reporting has its own signal-based mechanism to interrupt the
++	 * other threads, so this is okay.
++	 */
++	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);
++
++	mono_thread_set_name_constant_ignore_error (thread, "Crash Report Leader", MonoSetThreadNameFlag_None);
++
++	mono_thread_set_state (mono_thread_internal_current (), ThreadState_Background);
++
++	/* This thread is always in async context */
++	mono_thread_info_set_is_async_context (TRUE);
++	
++	mono_atomic_store_i32 (&summarizer_leader_data.leader_running, 1);
++	while (TRUE) {
++		/* Leader ready to receive crashe report requests */
++		MONO_ENTER_GC_SAFE;
++		/* allow interruptions */
++		while (mono_os_sem_wait (&summarizer_leader_data.begin_crash_report, MONO_SEM_FLAGS_ALERTABLE) < 0);
++		MONO_EXIT_GC_SAFE;
++		LEADER_LOG ("Crash report leader %p beginning collection for originator %p\n", (gpointer)(intptr_t)summarizer_leader_data.leader_tid, (gpointer)(intptr_t)summarizer_leader_data.originator.originator_tid);
++
++		/* Leader is collecting thread ids for a crash */
++
++		/* collect a crash report */
++		summarizer_leader_collect_thread_ids (summarizer_leader_data.originator.state);
++
++		summarizer_leader_data.originator.originator_index = -1;
++		summarizer_state_get_index_for_thread (summarizer_leader_data.originator.state, summarizer_leader_data.originator.originator_tid, &summarizer_leader_data.originator.originator_index);
++		if (summarizer_leader_data.originator.originator_index == -1)
++			summarizer_leader_adjust_tids_for_foreign_originator ();
++
++		/* wake up originator */
++		summarizer_leader_response_write (LEADER_RESPONSE_IDS_COLLECTED);
++
++		/* Leader is waiting for report originator before suspending the other threads */
++		int cmd;
++		if (!summarizer_leader_wait_for_command (&cmd))
++			continue; /* restart */
++		g_assert (cmd == LEADER_COMMAND_PROCEED_TO_SUSPEND);
++
++		/* Leader is suspending other threads */
++		summarizer_leader_suspend_others(summarizer_leader_data.originator.state, summarizer_leader_data.originator.originator_tid, summarizer_leader_data.originator.originator_index);
++		summarizer_leader_response_write (LEADER_RESPONSE_THREADS_SUSPENDED);
++
++		/* Pause leader until originator populates its stack data */
++
++		if (!summarizer_leader_wait_for_command (&cmd))
++			continue;
++		g_assert (cmd == LEADER_COMMAND_PROCEED_TO_TERM);
++
++		/* Finish up the crash report */
++		summarizer_state_wait_and_term (summarizer_leader_data.leader_tid, summarizer_leader_data.originator.state, summarizer_leader_data.originator.out, summarizer_leader_data.originator.working_mem, summarizer_leader_data.originator.provided_size, summarizer_leader_data.originator.originator_summary);
++		LEADER_LOG ("Crash report leader finished reporting.  Ready for next crash\n");
++		summarizer_leader_response_write (LEADER_RESPONSE_STACKS_WALKED);
++	}
++}
++
++static gboolean
++summarizer_leader_is_running (void)
++{
++	return mono_atomic_load_i32 (&summarizer_leader_data.leader_running);
++}
++
++
++static void
++summarizer_leader_init (void)
++{
++	/* TODO: do we really need two semaphores?  There's always one
++	 * originator and one leader - we can signal the leader to begin by
++	 * posting a command. */
++	mono_os_sem_init (&summarizer_leader_data.begin_crash_report, 0);
++	mono_os_sem_init (&summarizer_leader_data.leader_commanded, 0);
++	/* Can't create the leader thread early on because MonoInternalThread needs the corlib InternalThread type */
++	int res = pipe (summarizer_leader_data.response_fds);
++	g_assert (!res);
++}
++
++void
++mono_summarizer_create_leader_thread (void)
++{
++	ERROR_DECL (error);
++
++	MonoInternalThread *leader = mono_thread_create_internal (mono_get_root_domain (), summarizer_leader, NULL, MONO_THREAD_CREATE_FLAGS_NONE, error);
++	mono_error_assert_ok (error);
++
++	summarizer_leader_data.leader_tid = thread_get_tid (leader);
++}
++static void
++summarizer_originator_prepare (MonoSummarizerOriginator *orig, SummarizerGlobalState *state, MonoNativeThreadId tid, MonoContext *ctx, gchar **out, gchar *working_mem, size_t provided_size)
++{
++	orig->state = state;
++	orig->originator_tid = tid;
++	orig->originator_ctx = ctx;
++	orig->out = out;
++	orig->working_mem = working_mem;
++	orig->provided_size = provided_size;
++}
++
++static void
++summarizer_leader_set_originator_summary (MonoThreadSummary *originator_summary)
++{
++	summarizer_leader_data.originator.originator_summary = originator_summary;
++}
++
++
++/* returns 0 if leader is not running and crash reporting should be done on the originator thread.
++ * returns <0 if leader could not collect a crash report.
++ * otherwise returns 1
++ */
++static int
++summarizer_originate_crash_report (SummarizerGlobalState *state, MonoNativeThreadId originator_tid, MonoContext *ctx, gchar **out, gchar *working_mem, size_t provided_size)
++{
++	/* FIXME: we already have a mechanism for gating requests in mono_threads_summarize, don't need another one here */
++	if (!summarizer_leader_is_running ()) {
++		/* FIXME: in that case, just gather the crash report on the main thread - it's early during startup */
++		g_async_safe_printf ("crash summarizer leader thread is not running. collecting crash report syncronously.\n");
++		return 0;
++	}
++
++	if (mono_native_thread_id_equals (originator_tid, summarizer_leader_data.leader_tid)) {
++		g_async_safe_printf ("crash summarizer leader thread crashed.  collecting a crash report synchronously\n");
++		/* Make it look like there's no summarizer leader */
++		mono_atomic_store_i32 (&summarizer_leader_data.leader_running, 0);
++		memset (&summarizer_leader_data.leader_tid, 0, sizeof (summarizer_leader_data.leader_tid));
++		/* Collect the crash report synchronously on this thread */
++		return 0;
++	}
++
++	summarizer_originator_prepare (&summarizer_leader_data.originator, state, originator_tid, ctx, out, working_mem, provided_size);
++	/* we're intentionally not switching to GC Safe mode in case we crashed in the coop state machine */
++	mono_os_sem_post (&summarizer_leader_data.begin_crash_report);
++
++	return summarizer_leader_response_read ();
++}
++
++
+ static void
+ collect_thread_id (gpointer key, gpointer value, gpointer user)
+ {
+@@ -6382,24 +6678,67 @@ collect_thread_ids (MonoNativeThreadId *thread_ids, int max_threads)
+ 	return ud.nthreads;
+ }
+ 
++
++/*
++ * Try to initialize the global summarizer thread.  At this point the caller
++ * doesn't know if it's the crash originator, or if another crash is in
++ * progress and the current thread was asked to summarize its state.  Returns
++ * TRUE if the current thread is to be the crash originator, returns FALSE if
++ * there's already a crash collection in progress.
++ */
+ static gboolean
+-summarizer_state_init (SummarizerGlobalState *state, MonoNativeThreadId current, int *my_index)
++summarizer_state_init (SummarizerGlobalState *state)
+ {
+ 	gint32 started_state = mono_atomic_cas_i32 (&state->has_owner, 1 /* set */, 0 /* compare */);
+ 	gboolean not_started = started_state == 0;
+-	if (not_started) {
+-		state->nthreads = collect_thread_ids (state->thread_array, MAX_NUM_THREADS);
++	if (not_started)
+ 		mono_os_sem_init (&state->update, 0);
++	return not_started;
++}
++
++static void
++summarizer_state_collect_thread_ids (SummarizerGlobalState *state)
++{
++	state->nthreads = collect_thread_ids (state->thread_array, MAX_NUM_THREADS);
++}
++
++static void
++summarizer_leader_collect_thread_ids (SummarizerGlobalState *state)
++{
++	summarizer_state_collect_thread_ids (state);
++
++}
++
++static void
++summarizer_leader_adjust_tids_for_foreign_originator (void)
++{
++	if (summarizer_leader_data.originator.originator_index == -1) {
++		/* The crash originator is not in Mono's thread list - it's some foreign thread that crashed in native code */
++		/* Add a slot for it at the end of the summarizer global state */
++		SummarizerGlobalState *state = summarizer_leader_data.originator.state;
++		if (state->nthreads < MAX_NUM_THREADS - 1) {
++			int originator_index = state->nthreads++;
++			state->thread_array [originator_index] = summarizer_leader_data.originator.originator_tid;
++			summarizer_leader_data.originator.originator_index = originator_index;
++		}
+ 	}
++}
+ 
++static int
++summarizer_leader_get_originator_index (void)
++{
++	return summarizer_leader_data.originator.originator_index;
++}
++
++static void
++summarizer_state_get_index_for_thread (SummarizerGlobalState *state, MonoNativeThreadId current, int *my_index)
++{
+ 	for (int i = 0; i < state->nthreads; i++) {
+ 		if (state->thread_array [i] == current) {
+ 			*my_index = i;
+ 			break;
+ 		}
+ 	}
+-
+-	return not_started;
+ }
+ 
+ static void
+@@ -6414,23 +6753,38 @@ summarizer_signal_other_threads (SummarizerGlobalState *state, MonoNativeThreadI
+ 
+ 		if (i == current_idx)
+ 			continue;
++		MonoNativeThreadId tid = state->thread_array [i];
++
++		if (mono_native_thread_id_equals (tid, summarizer_leader_data.leader_tid))
++			continue;
++		
+ 	#ifdef HAVE_PTHREAD_KILL
+ 		pthread_kill (state->thread_array [i], SIGTERM);
+ 
+ 		if (!state->silent)
+-			g_async_safe_printf("Pkilling 0x%" G_GSIZE_FORMAT "x from 0x%" G_GSIZE_FORMAT "x\n", (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (state->thread_array [i]), (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (current));
++			g_async_safe_printf("Pkilling %p from %p\n", (gpointer)(intptr_t) state->thread_array [i], (gpointer)(intptr_t)current);
+ 	#else
+ 		g_error ("pthread_kill () is not supported by this platform");
+ 	#endif
+ 	}
+ }
+ 
++static void
++summarizer_leader_suspend_others (SummarizerGlobalState *state, MonoNativeThreadId originator, int originator_idx)
++{
++	summarizer_signal_other_threads (state, originator, originator_idx);
++}
++
+ // Returns true when there are shared global references to "this_thread"
+ static gboolean
+ summarizer_post_dump (SummarizerGlobalState *state, MonoThreadSummary *this_thread, int current_idx)
+ {
+ 	mono_memory_barrier ();
+ 
++	/* If the thread wasn't assigned a slot, don't save its dump */
++	if (current_idx < 0)
++		return FALSE;
++
+ 	gpointer old = mono_atomic_cas_ptr ((volatile gpointer *)&state->all_threads [current_idx], this_thread, NULL);
+ 
+ 	if (old == GINT_TO_POINTER (-1)) {
+@@ -6504,20 +6858,24 @@ summarizer_state_term (SummarizerGlobalState *state, gchar **out, gchar *mem, si
+ 	mono_summarize_timeline_phase_log (MonoSummaryManagedStacks);
+ 	for (int i=0; i < state->nthreads; i++) {
+ 		threads [i] = summarizer_try_read_thread (state, i);
++		LEADER_LOG("managed stack for thread %d (%p) \"%s\"\n", i, threads[i] ? (gpointer)threads[i]->native_thread_id : (gpointer)NULL, threads[i] && threads[i]->name[0] != '\0' ? threads[i]->name : "");
+ 		if (!threads [i])
+ 			continue;
+ 
+-		// We are doing this dump on the controlling thread because this isn't
++		// We are doing this dump on the leader or controlling thread because this isn't
+ 		// an async context sometimes. There's still some reliance on malloc here, but it's
+-		// much more stable to do it all from the controlling thread.
++		// much more stable to do it all from the leader or controlling thread.
+ 		//
+ 		// This is non-null, checked in mono_threads_summarize
+ 		// with early exit there
+ 		mono_get_eh_callbacks ()->mono_summarize_managed_stack (threads [i]);
++
++		LEADER_LOG("finished managed stack for thread %d (%p)\n", i, threads[i] ? (gpointer)threads[i]->native_thread_id : (gpointer)NULL);
+ 	}
+ 
+ 	/* The value of the breadcrumb should match the "StackHash" value written by `mono_merp_write_fingerprint_payload` */
+ 	mono_create_crash_hash_breadcrumb (controlling);
++	LEADER_LOG("wrote hash breadcrumb for controlling thread %p", controlling ? (gpointer)controlling->native_thread_id : (gpointer)NULL);
+ 
+ 	MonoStateWriter writer;
+ 	memset (&writer, 0, sizeof (writer));
+@@ -6555,6 +6913,22 @@ summarizer_state_wait (MonoThreadSummary *thread)
+ 		mono_os_sem_timedwait (&thread->done_wait, milliseconds_in_second, MONO_SEM_FLAGS_NONE);
+ }
+ 
++static void
++summarizer_state_wait_and_term (MonoNativeThreadId caller_tid, SummarizerGlobalState *state, gchar **out, gchar *working_mem, size_t provided_size, MonoThreadSummary *originator_summary)
++{
++	if (!state->silent)
++		g_async_safe_printf("Entering thread summarizer pause from %p\n", (gpointer)(intptr_t)caller_tid);
++
++	// Wait up to 2 seconds for all of the other threads to catch up
++	summary_timedwait (state, 2);
++
++	if (!state->silent)
++		g_async_safe_printf("Finished thread summarizer pause from %p.\n", (gpointer)(intptr_t)caller_tid);
++
++	// Dump and cleanup all the stack memory
++	summarizer_state_term (state, out, working_mem, provided_size, originator_summary);
++}
++
+ static gboolean
+ mono_threads_summarize_execute_internal (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gchar *working_mem, size_t provided_size, gboolean this_thread_controls)
+ {
+@@ -6562,10 +6936,56 @@ mono_threads_summarize_execute_internal (MonoContext *ctx, gchar **out, MonoStac
+ 
+ 	int current_idx;
+ 	MonoNativeThreadId current = mono_native_thread_id_get ();
+-	gboolean thread_given_control = summarizer_state_init (&state, current, &current_idx);
++	gboolean thread_given_control = summarizer_state_init (&state);
+ 
+ 	g_assert (this_thread_controls == thread_given_control);
+ 
++	/* if true, the crash leader is not running yet - collect the report on the current originating thread */
++	gboolean collect_synchronously = FALSE;
++	if (this_thread_controls) {
++		int res = summarizer_originate_crash_report (&state, current, ctx, out, working_mem, provided_size);
++		
++		/*
++		 * We need to coordinate the originator and the leader in a few
++		 * places.
++		 * 
++		 * The leader needs to pause to after collecting the thread ids
++		 * before suspending the non-originator threads, and again
++		 * while the originator is dumping its own stack.
++		 * 
++		 * The originator needs to wait for the leader to collect the
++		 * thread IDs and to tell it its assigned slot. Then it tells
++		 * the leader to suspend the others, dumps its own memory, then
++		 * tell the leader to dump the whole crash report and waits for
++		 * it to reply when it's done.
++		 */
++				
++		if (res == 0) {
++			/* collect the crash report synchronously */
++			collect_synchronously = TRUE;
++		} else if (res < 0) {
++			g_async_safe_printf ("Crash summary leader could not collect thread data.  No crash report will be created.\n");
++			/* something went wrong */
++			return FALSE;
++		} else {
++			g_assert (res == LEADER_RESPONSE_IDS_COLLECTED);
++			/* get the thread index from the crash leader */
++			current_idx = summarizer_leader_get_originator_index ();
++			if (current_idx < 0) {
++				g_async_safe_printf ("Summarizer originator not in the thread list\n");
++			} else {
++				LEADER_LOG ("Summarizer originator has index %d\n", current_idx);
++			}
++		}
++	}
++
++	if (this_thread_controls && collect_synchronously) {
++		summarizer_state_collect_thread_ids (&state);
++	}
++
++	if (!this_thread_controls || collect_synchronously)
++		summarizer_state_get_index_for_thread (&state, current, &current_idx);
++
+ 	if (state.nthreads == 0) {
+ 		if (!silent)
+ 			g_async_safe_printf("No threads attached to runtime.\n");
+@@ -6574,18 +6994,31 @@ mono_threads_summarize_execute_internal (MonoContext *ctx, gchar **out, MonoStac
+ 	}
+ 
+ 	if (this_thread_controls) {
+-		g_assert (working_mem);
+-
+ 		mono_summarize_timeline_phase_log (MonoSummarySuspendHandshake);
+ 		state.silent = silent;
+-		summarizer_signal_other_threads (&state, current, current_idx);
++		if (!collect_synchronously) {
++			/*
++			 * crash leader signals the other threads, but not the
++			 * originator thread - we're going to dump by
++			 * ourselves, below.
++			 */
++			summarizer_leader_post_command (LEADER_COMMAND_PROCEED_TO_SUSPEND);
++			int res = summarizer_leader_response_read ();
++			g_assert (res == LEADER_RESPONSE_THREADS_SUSPENDED);
++		} else {
++			summarizer_signal_other_threads (&state, current, current_idx);
++		}
+ 		mono_summarize_timeline_phase_log (MonoSummaryUnmanagedStacks);
+ 	}
+ 
+ 	MonoStateMem mem;
+ 	gboolean success = mono_state_alloc_mem (&mem, (long) current, sizeof (MonoThreadSummary));
+-	if (!success)
++	if (!success) {
++		if (this_thread_controls && !collect_synchronously) {
++			summarizer_leader_post_command (LEADER_COMMAND_CANCEL);
++		}
+ 		return FALSE;
++	}
+ 
+ 	MonoThreadSummary *this_thread = (MonoThreadSummary *) mem.mem;
+ 
+@@ -6597,24 +7030,23 @@ mono_threads_summarize_execute_internal (MonoContext *ctx, gchar **out, MonoStac
+ 		// Store a reference to our stack memory into global state
+ 		gboolean success = summarizer_post_dump (&state, this_thread, current_idx);
+ 		if (!success && !state.silent)
+-			g_async_safe_printf("Thread 0x%" G_GSIZE_FORMAT "x reported itself.\n", (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (current));
++			g_async_safe_printf("Thread %p reported itself.\n", (gpointer)(intptr_t)current);
+ 	} else if (!state.silent) {
+-		g_async_safe_printf("Thread 0x%" G_GSIZE_FORMAT "x couldn't report itself.\n", (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (current));
++		g_async_safe_printf("Thread %p couldn't report itself.\n", (gpointer)(intptr_t)current);
+ 	}
+ 
+ 	// From summarizer, wait and dump.
+ 	if (this_thread_controls) {
+-		if (!state.silent)
+-			g_async_safe_printf("Entering thread summarizer pause from 0x%" G_GSIZE_FORMAT "x\n", (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (current));
+-
+-		// Wait up to 2 seconds for all of the other threads to catch up
+-		summary_timedwait (&state, 2);
+-
+-		if (!state.silent)
+-			g_async_safe_printf("Finished thread summarizer pause from 0x%" G_GSIZE_FORMAT "x.\n", (gsize)MONO_NATIVE_THREAD_ID_TO_UINT (current));
+-
+-		// Dump and cleanup all the stack memory
+-		summarizer_state_term (&state, out, working_mem, provided_size, this_thread);
++		if (collect_synchronously) {
++			summarizer_state_wait_and_term (current, &state, out, working_mem, provided_size, this_thread);
++		} else {
++			summarizer_leader_set_originator_summary (this_thread);
++			summarizer_leader_post_command (LEADER_COMMAND_PROCEED_TO_TERM);
++			/* blocks here until leader is done, keeping
++			 * originator's stack memory alive for the dumper */
++			int res = summarizer_leader_response_read ();
++			g_assert (res == LEADER_RESPONSE_STACKS_WALKED);
++		}
+ 	} else {
+ 		// Wait here, keeping our stack memory alive
+ 		// for the dumper
+@@ -6634,6 +7066,7 @@ void
+ mono_threads_summarize_init (void)
+ {
+ 	summarizer_supervisor_init ();
++	summarizer_leader_init ();
+ }
+ 
+ gboolean
+@@ -6660,6 +7093,7 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gb
+ 	static gint64 request_available_to_run = 1;
+ 	gint64 this_request_id = mono_atomic_inc_i64 ((volatile gint64 *) &next_pending_request_id);
+ 
++	g_async_safe_printf ("Thread %p starting summarize_execute\n", (gpointer)(intptr_t)mono_native_thread_id_get ());
+ 	// This is a global queue of summary requests. 
+ 	// It's not safe to signal a thread while they're in the
+ 	// middle of a dump. Dladdr is not reentrant. It's the one lock
+@@ -6682,13 +7116,15 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gb
+ 		gint64 next_request_id = mono_atomic_load_i64 ((volatile gint64 *) &request_available_to_run);
+ 
+ 		if (next_request_id == this_request_id) {
+-			gboolean already_async = mono_thread_info_is_async_context ();
++			gboolean foreign = mono_thread_info_current_unchecked () == NULL;
++			gboolean already_async = foreign || mono_thread_info_is_async_context ();
+ 			if (!already_async)
+ 				mono_thread_info_set_is_async_context (TRUE);
+ 
+ 			SummarizerSupervisorState synch;
+ 			if (summarizer_supervisor_start (&synch)) {
+ 				g_assert (mem);
++				
+ 				success = mono_threads_summarize_execute_internal (ctx, out, hashes, silent, mem, provided_size, TRUE);
+ 				summarizer_supervisor_end (&synch);
+ 			}
+diff --git a/mono/mini/debugger-agent.c b/mono/mini/debugger-agent.c
+index 54c0ca97801..b2787edce48 100644
+--- a/mono/mini/debugger-agent.c
++++ b/mono/mini/debugger-agent.c
+@@ -5161,6 +5161,10 @@ ss_clear_for_assembly (SingleStepReq *req, MonoAssembly *assembly)
+ static void
+ mono_debugger_agent_send_crash (char *json_dump, MonoStackHash *hashes, int pause)
+ {
++	/* Did we crash on an unattached thread?  Can't do runtime notifications from there */
++	if (!mono_thread_info_current_unchecked ())
++		return;
++
+ 	MONO_ENTER_GC_UNSAFE;
+ #ifndef DISABLE_CRASH_REPORTING
+ 	int suspend_policy;
+diff --git a/mono/mini/mini-exceptions.c b/mono/mini/mini-exceptions.c
+index e712a623bb4..643450f2fd1 100644
+--- a/mono/mini/mini-exceptions.c
++++ b/mono/mini/mini-exceptions.c
+@@ -1751,6 +1751,10 @@ mono_summarize_unmanaged_stack (MonoThreadSummary *out)
+ 	// Summarize unmanaged stack
+ 	// 
+ #ifdef HAVE_BACKTRACE_SYMBOLS
++	MonoDomain *domain = mono_domain_get ();
++
++	gboolean has_jit_tls = mono_tls_get_jit_tls () != NULL;
++
+ 	intptr_t frame_ips [MONO_MAX_SUMMARY_FRAMES];
+ 
+ 	out->num_unmanaged_frames = backtrace ((void **)frame_ips, MONO_MAX_SUMMARY_FRAMES);
+@@ -1761,11 +1765,16 @@ mono_summarize_unmanaged_stack (MonoThreadSummary *out)
+ 		const char* module_buf = frame->unmanaged_data.module;
+ 		int success = mono_get_portable_ip (ip, &frame->unmanaged_data.ip, &frame->unmanaged_data.offset, &module_buf, (char *) frame->str_descr);
+ 
++		/* If the thread is not attached to the JIT, (ie crashed native
++		 * thread), don't try to look for managed method info - it will
++		 * assert in mono_jit_info_table_find_internal */
++		if (!has_jit_tls)
++			continue;
++
+ 		/* attempt to look up any managed method at that ip */
+ 		/* TODO: Trampolines - follow examples from mono_print_method_from_ip() */
+ 
+ 		MonoJitInfo *ji;
+-		MonoDomain *domain = mono_domain_get ();
+ 		MonoDomain *target_domain;
+ 		ji = mini_jit_info_table_find_ext (domain, (char *)ip, TRUE, &target_domain);
+ 		if (ji) {
+@@ -1796,7 +1805,7 @@ mono_summarize_unmanaged_stack (MonoThreadSummary *out)
+ 
+ 	MonoThreadInfo *thread = mono_thread_info_current_unchecked ();
+ 	out->info_addr = (intptr_t) thread;
+-	out->jit_tls = thread->jit_data;
++	out->jit_tls = thread ? thread->jit_data : NULL;
+ 	out->domain = mono_domain_get ();
+ 
+ 	if (!out->ctx) {
+diff --git a/mono/mini/mini-runtime.c b/mono/mini/mini-runtime.c
+index 4619638f31b..e04626d7ff2 100644
+--- a/mono/mini/mini-runtime.c
++++ b/mono/mini/mini-runtime.c
+@@ -3351,6 +3351,8 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
+ 			mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
+ 			return;
+ 		}
++		/* thread not registered with the runtime, make sure we return now. */
++		return;
+ 	}
+ #endif
+ 
+diff --git a/mono/tests/libtest.c b/mono/tests/libtest.c
+index e5e5f2f14d3..2af1ef5302b 100644
+--- a/mono/tests/libtest.c
++++ b/mono/tests/libtest.c
+@@ -8118,6 +8118,34 @@ mono_test_MerpCrashSignalIll (void)
+ #endif
+ }
+ 
++#ifndef HOST_WIN32
++void*
++foreign_thread_crash_body (void* ud)
++{
++	while (1) {
++		fprintf (stderr, "alive\n");
++		sleep (2);
++	}
++	return NULL;
++}
++#endif
++
++LIBTEST_API void mono_test_MerpCrashOnForeignThread (void)
++{
++
++#ifndef HOST_WIN32
++	pthread_t t;
++	int res;
++
++	res = pthread_create (&t, NULL, foreign_thread_crash_body, NULL);
++
++	sleep (1);
++	pthread_kill (t, SIGILL);
++
++	pthread_join (t, NULL);
++#endif
++}
++
+ #ifdef __cplusplus
+ } // extern C
+ #endif
+diff --git a/mono/tests/merp-crash-test.cs b/mono/tests/merp-crash-test.cs
+index d534a64fae5..93a9426c45d 100644
+--- a/mono/tests/merp-crash-test.cs
++++ b/mono/tests/merp-crash-test.cs
+@@ -55,7 +55,8 @@ static CrasherClass ()
+ 			Crashers.Add(new Crasher ("MerpCrashExceptionHook", MerpCrashUnhandledExceptionHook));
+ 
+ 			// Specific Edge Cases
+-			Crashers.Add(new Crasher ("MerpCrashDladdr", MerpCrashDladdr));
++			//FIXME: crash in dlopen holds the global dyld lock, which we need for stack walks.
++			//Crashers.Add(new Crasher ("MerpCrashDladdr", MerpCrashDladdr));
+ 			Crashers.Add(new Crasher ("MerpCrashSnprintf", MerpCrashSnprintf));
+ 			Crashers.Add(new Crasher ("MerpCrashDomainUnload", MerpCrashDomainUnload));
+ 			Crashers.Add(new Crasher ("MerpCrashUnbalancedGCSafe", MerpCrashUnbalancedGCSafe));
+@@ -66,6 +67,7 @@ static CrasherClass ()
+ 			Crashers.Add(new Crasher  ("MerpCrashSignalSegv", MerpCrashSignalSegv));
+ 			Crashers.Add(new Crasher  ("MerpCrashSignalIll", MerpCrashSignalIll));
+ 			Crashers.Add(new Crasher ("MerpCrashTestBreadcrumbs", MerpCrashTestBreadcrumbs, validator: ValidateBreadcrumbs));
++			Crashers.Add(new Crasher ("MerpCrashOnForeignThread", MerpCrashOnForeignThread));
+ 		}
+ 
+ 		public static void 
+@@ -245,6 +247,14 @@ public static void
+ 			mono_test_MerpCrashSignalSegv ();
+ 		}
+ 
++		[DllImport("libtest")]
++		public static extern void mono_test_MerpCrashOnForeignThread ();
++
++		public static void
++		MerpCrashOnForeignThread ()
++		{
++			mono_test_MerpCrashOnForeignThread ();
++		}
+ 
+ 		private static object jsonGetKey (object o, string key) => (o as Dictionary<string,object>)[key];
+ 		private static object jsonGetKeys (object o, params string[] keys) {
+diff --git a/mono/utils/hazard-pointer.c b/mono/utils/hazard-pointer.c
+index 8fe373e64fb..e01912d8121 100644
+--- a/mono/utils/hazard-pointer.c
++++ b/mono/utils/hazard-pointer.c
+@@ -187,7 +187,7 @@ mono_hazard_pointer_get (void)
+ 
+ 	if (small_id < 0) {
+ 		static MonoThreadHazardPointers emerg_hazard_table;
+-		g_warning ("Thread %p may have been prematurely finalized", (gpointer) (gsize) mono_native_thread_id_get ());
++		g_warning ("Thread %p may have been prematurely finalized\n", (gpointer) (gsize) mono_native_thread_id_get ());
+ 		return &emerg_hazard_table;
+ 	}
+ 
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0025-2020-02-Fix-memory-leak-during-data-registration-211.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0025-2020-02-Fix-memory-leak-during-data-registration-211.patch
@@ -1,0 +1,85 @@
+From 35bf914659f88753c1c080c125164fc878645c74 Mon Sep 17 00:00:00 2001
+From: Marius Ungureanu <marius.ungureanu@xamarin.com>
+Date: Fri, 25 Jun 2021 13:57:46 +0300
+Subject: [PATCH 25/32] [2020-02] Fix memory leak during data registration
+ (#21107) (#21116)
+
+Co-authored-by: Fan Yang <52458914+fanyang-mono@users.noreply.github.com>
+---
+ mono/mini/mini-generic-sharing.c | 30 +++++++++++++++++++++++++++---
+ 1 file changed, 27 insertions(+), 3 deletions(-)
+
+diff --git a/mono/mini/mini-generic-sharing.c b/mono/mini/mini-generic-sharing.c
+index 45528b9cb45..90b19017a5b 100644
+--- a/mono/mini/mini-generic-sharing.c
++++ b/mono/mini/mini-generic-sharing.c
+@@ -2758,6 +2758,7 @@ mini_rgctx_info_type_to_patch_info_type (MonoRgctxInfoType info_type)
+  * @method: a method
+  * @in_mrgctx: whether to put the data into the MRGCTX
+  * @data: the info data
++ * @did_register: whether data was registered
+  * @info_type: the type of info to register about data
+  * @generic_context: a generic context
+  *
+@@ -2766,7 +2767,7 @@ mini_rgctx_info_type_to_patch_info_type (MonoRgctxInfoType info_type)
+  * encoded slot number.
+  */
+ static guint32
+-lookup_or_register_info (MonoClass *klass, MonoMethod *method, gboolean in_mrgctx, gpointer data,
++lookup_or_register_info (MonoClass *klass, MonoMethod *method, gboolean in_mrgctx, gpointer data, gboolean *did_register,
+ 						 MonoRgctxInfoType info_type, MonoGenericContext *generic_context)
+ {
+ 	int type_argc = 0;
+@@ -2815,7 +2816,10 @@ lookup_or_register_info (MonoClass *klass, MonoMethod *method, gboolean in_mrgct
+ 
+ 	/* We haven't found the info */
+ 	if (index == -1)
++	{
+ 		index = register_info (klass, type_argc, data, info_type);
++		*did_register = TRUE;
++	}
+ 
+ 	/* interlocked by loader lock */
+ 	if (index > UnlockedRead (&rgctx_max_slot_number))
+@@ -4145,6 +4149,8 @@ int
+ mini_get_rgctx_entry_slot (MonoJumpInfoRgctxEntry *entry)
+ {
+ 	gpointer entry_data = NULL;
++	gboolean did_register = FALSE;
++	guint32 result = -1;
+ 
+ 	switch (entry->data->type) {
+ 	case MONO_PATCH_INFO_CLASS:
+@@ -4211,9 +4217,27 @@ mini_get_rgctx_entry_slot (MonoJumpInfoRgctxEntry *entry)
+ 	}
+ 
+ 	if (entry->in_mrgctx)
+-		return lookup_or_register_info (entry->d.method->klass, entry->d.method, entry->in_mrgctx, entry_data, entry->info_type, mono_method_get_context (entry->d.method));
++		result = lookup_or_register_info (entry->d.method->klass, entry->d.method, entry->in_mrgctx, entry_data, &did_register, entry->info_type, mono_method_get_context (entry->d.method));
+ 	else
+-		return lookup_or_register_info (entry->d.klass, NULL, entry->in_mrgctx, entry_data, entry->info_type, mono_class_get_context (entry->d.klass));
++		result = lookup_or_register_info (entry->d.klass, NULL, entry->in_mrgctx, entry_data, &did_register, entry->info_type, mono_class_get_context (entry->d.klass));
++
++	if (!did_register)
++		switch (entry->data->type) {
++		case MONO_PATCH_INFO_GSHAREDVT_CALL:
++		case MONO_PATCH_INFO_VIRT_METHOD:
++		case MONO_PATCH_INFO_DELEGATE_TRAMPOLINE:
++			g_free (entry_data);
++			break;
++		case MONO_PATCH_INFO_GSHAREDVT_METHOD: {
++			g_free (((MonoGSharedVtMethodInfo *) entry_data)->entries);
++			g_free (entry_data);
++			break;
++		}
++		default :
++			break;
++		}
++
++	return result;
+ }
+ 
+ static gboolean gsharedvt_supported;
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0026-mini-Add-GC-Unsafe-transitions-in-mono_pmip-21186.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0026-mini-Add-GC-Unsafe-transitions-in-mono_pmip-21186.patch
@@ -1,0 +1,70 @@
+From 8b6809243db21a9ab3e2c21570958ab9c537ce29 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Aleksey=20Kliger=20=28=CE=BBgeek=29?= <alklig@microsoft.com>
+Date: Thu, 12 Aug 2021 20:29:41 -0400
+Subject: [PATCH 26/32] [mini] Add GC Unsafe transitions in mono_pmip (#21186)
+
+Add a new mono_pmip_u that doesn't do the transition.
+
+The intent is that Mono developers in the debugger can call still call
+mono_pmip_u if the thread state machine is in a broken state.
+---
+ mono/mini/mini-runtime.c | 20 ++++++++++++++++++++
+ mono/mini/mini-runtime.h |  1 +
+ 2 files changed, 21 insertions(+)
+
+diff --git a/mono/mini/mini-runtime.c b/mono/mini/mini-runtime.c
+index e04626d7ff2..18d99134fbc 100644
+--- a/mono/mini/mini-runtime.c
++++ b/mono/mini/mini-runtime.c
+@@ -191,9 +191,23 @@ find_tramp (gpointer key, gpointer value, gpointer user_data)
+ 		ud->method = (MonoMethod*)key;
+ }
+ 
++static char*
++mono_get_method_from_ip_u (void *ip);
++
+ /* debug function */
+ char*
+ mono_get_method_from_ip (void *ip)
++{
++	char *result;
++	MONO_ENTER_GC_UNSAFE;
++	result = mono_get_method_from_ip_u (ip);
++	MONO_EXIT_GC_UNSAFE;
++	return result;
++}
++
++/* debug function */
++static char*
++mono_get_method_from_ip_u (void *ip)
+ {
+ 	MonoJitInfo *ji;
+ 	MonoMethod *method;
+@@ -263,6 +277,12 @@ mono_pmip (void *ip)
+ 	return mono_get_method_from_ip (ip);
+ }
+ 
++G_GNUC_UNUSED char *
++mono_pmip_u (void *ip)
++{
++	return mono_get_method_from_ip_u (ip);
++}
++
+ /**
+  * mono_print_method_from_ip:
+  * \param ip an instruction pointer address
+diff --git a/mono/mini/mini-runtime.h b/mono/mini/mini-runtime.h
+index 122b107e5d3..ebe6f607e83 100644
+--- a/mono/mini/mini-runtime.h
++++ b/mono/mini/mini-runtime.h
+@@ -495,6 +495,7 @@ MONO_LLVM_INTERNAL const char*mono_ji_type_to_string           (MonoJumpInfoType
+ void      mono_print_ji                     (const MonoJumpInfo *ji);
+ MONO_API void      mono_print_method_from_ip         (void *ip);
+ MONO_API char     *mono_pmip                         (void *ip);
++MONO_API char     *mono_pmip_u                       (void *ip);
+ MONO_API int mono_ee_api_version (void);
+ gboolean  mono_debug_count                  (void);
+ 
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0027-Adding-null-check-to-avoid-abort-when-invalid-IL-is-.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0027-Adding-null-check-to-avoid-abort-when-invalid-IL-is-.patch
@@ -1,0 +1,31 @@
+From f41fc8b1333ac74e21e31ffdfa56281e7b20816e Mon Sep 17 00:00:00 2001
+From: "github-actions[bot]"
+ <41898282+github-actions[bot]@users.noreply.github.com>
+Date: Thu, 19 Aug 2021 15:41:09 +0200
+Subject: [PATCH 27/32] Adding null check to avoid abort when invalid IL is
+ encountered (#21195)
+
+When a callvirt instruction is encountered on a static method, there is
+a hard abort/crash. This commit avoids the problem.
+
+Co-authored-by: Bill Holmes <bill.holmes@unity3d.com>
+---
+ mono/mini/method-to-ir.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mono/mini/method-to-ir.c b/mono/mini/method-to-ir.c
+index a2639dc7431..056e8776400 100644
+--- a/mono/mini/method-to-ir.c
++++ b/mono/mini/method-to-ir.c
+@@ -7222,7 +7222,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
+ 
+ 			sp -= n;
+ 
+-			if (virtual_ && cmethod && sp [0]->opcode == OP_TYPED_OBJREF) {
++			if (virtual_ && cmethod && sp [0] && sp [0]->opcode == OP_TYPED_OBJREF) {
+ 				ERROR_DECL (error);
+ 
+ 				MonoMethod *new_cmethod = mono_class_get_virtual_method (sp [0]->klass, cmethod, FALSE, error);
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0028-Mono.Profiler.Aot-Write-true-string-wire-length-2119.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0028-Mono.Profiler.Aot-Write-true-string-wire-length-2119.patch
@@ -1,0 +1,37 @@
+From 1e649b6338669d32c92bc882af968f68e4c14896 Mon Sep 17 00:00:00 2001
+From: "github-actions[bot]"
+ <41898282+github-actions[bot]@users.noreply.github.com>
+Date: Thu, 19 Aug 2021 15:46:07 +0200
+Subject: [PATCH 28/32] [Mono.Profiler.Aot] Write true string wire length
+ (#21196)
+
+In some cases, it seems like Mono.Profiler.Aot `ProfileWriter` can produce custom profiles that are unable to be read by `ProfileReader` (or `aot-compiler.c`). There are a few reports [here](https://github.com/xamarin/xamarin-android/issues/4602#issuecomment-618201419).
+
+I investigated and found a cause may be the writing of incorrect string length markers in situations where `String.Length` is less than the encoded byte length. In that kind of case, the reader falls out of sync with the record structure and quickly fails. [Here is an example dependency](https://www.fuget.org/packages/AuroraControls.Core/1.2020.520.2/lib/netstandard2.0/Aurora.dll) with members that can produce the issue (I guess the odd characters are caused by obfuscation).
+
+![image](https://user-images.githubusercontent.com/7392704/129899400-086a6e8a-373c-4601-837a-5255e7f93d82.png)
+
+I don't think the change requires a profile format version bump, as the format itself is unchanged.
+
+Co-authored-by: Ryan Davis <ryandavis.au@gmail.com>
+---
+ mcs/class/Mono.Profiler.Log/Mono.Profiler.Aot/ProfileWriter.cs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Aot/ProfileWriter.cs b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Aot/ProfileWriter.cs
+index e7be91e19d6..4c202900896 100644
+--- a/mcs/class/Mono.Profiler.Log/Mono.Profiler.Aot/ProfileWriter.cs
++++ b/mcs/class/Mono.Profiler.Log/Mono.Profiler.Aot/ProfileWriter.cs
+@@ -25,8 +25,8 @@ unsafe void WriteInt32 (int intValue)
+ 
+ 		void WriteString (string str)
+ 		{
+-			WriteInt32 (str.Length);
+ 			var buf = Encoding.UTF8.GetBytes (str);
++			WriteInt32 (buf.Length);
+ 			stream.Write (buf, 0, buf.Length);
+ 		}
+ 
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0029-2020-02-backport-metadata-fixes-21190.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0029-2020-02-backport-metadata-fixes-21190.patch
@@ -1,0 +1,115 @@
+From 3cf59ad33daa57120ec2d3ca97cfdff4c89ca372 Mon Sep 17 00:00:00 2001
+From: Marius Ungureanu <marius.ungureanu@xamarin.com>
+Date: Thu, 19 Aug 2021 16:51:01 +0300
+Subject: [PATCH 29/32] 2020 02 backport metadata fixes (#21190)
+
+* [mono] Fix race during mono_image_storage_open (#21142)
+
+* The mono_refcount_inc call in mono_image_storage_trypublish or
+  mono_image_storage_tryaddref may abort when racing against a
+  mono_image_storage_dtor that already decremented the refcount.
+
+This race triggered in some cases when building aspnetcore using a Mono-based dotnet host SDK.   The problem is that `mono_image_storage_close` runs outside the `mono_images_storage_lock` (and this may be unavoidable due to lock ordering concerns).  Therefore, we can have a refcount that was already decremented to zero, but before `mono_image_storage_dtor` finishes removing the object from `images_storage_hash`, a parallel `mono_image_storage_trypublish` may have retrieved it from there.  In that case, the `mono_refcount_inc` call will abort.
+
+Fixed by detecting that case via `mono_refcount_tryinc` instead, and simply treating the object as if it had already been removed.  It will in time actually get removed, either by the parallel `mono_image_storage_dtor`, or else by the `g_hash_table_insert` in `mono_image_storage_trypublish` (which will safely replace it with the new object, and `mono_image_storage_dtor` will then detect that and skip removal).
+
+Co-authored-by: uweigand <uweigand@users.noreply.github.com>
+
+* [metadata] Handle MONO_TYPE_FNPTR case in collect_type_images (#19434)
+
+Fixes abort when PTR-FNPTR field signature is encountered.
+
+Fixes https://github.com/mono/mono/issues/12098
+Fixes https://github.com/mono/mono/issues/17113
+Fixes https://github.com/mono/mono/issues/19433
+
+* Ensure generic parameter constraint type is included when building image (#19395)
+
+sets.
+
+Making associated change to type_in_image to also check the constrained type for a match. Re-adding asserts now they they no longer trigger.
+
+fixup, accidentally used old function
+
+adjusting coding convention to K&R
+
+Co-authored-by: monojenkins <jo.shields+jenkins@xamarin.com>
+Co-authored-by: uweigand <uweigand@users.noreply.github.com>
+Co-authored-by: Jeff Smith <whydoubt@gmail.com>
+Co-authored-by: Alex Thibodeau <alexthibodeau@unity3d.com>
+---
+ mono/metadata/image.c    | 10 ++++++++--
+ mono/metadata/metadata.c | 15 ++++++++++++---
+ 2 files changed, 20 insertions(+), 5 deletions(-)
+
+diff --git a/mono/metadata/image.c b/mono/metadata/image.c
+index b2ee484acdd..e9ba9bc6c32 100644
+--- a/mono/metadata/image.c
++++ b/mono/metadata/image.c
+@@ -1425,8 +1425,11 @@ mono_image_storage_trypublish (MonoImageStorage *candidate, MonoImageStorage **o
+ 	gboolean result;
+ 	mono_images_storage_lock ();
+ 	MonoImageStorage *val = (MonoImageStorage *)g_hash_table_lookup (images_storage_hash, candidate->key);
++	if (val && !mono_refcount_tryinc (val)) {
++		// We raced against a mono_image_storage_dtor in progress.
++		val = NULL;
++	}
+ 	if (val) {
+-		mono_refcount_inc (val);
+ 		*out_storage = val;
+ 		result = FALSE;
+ 	} else {
+@@ -1457,8 +1460,11 @@ mono_image_storage_tryaddref (const char *key, MonoImageStorage **found)
+ 	gboolean result = FALSE;
+ 	mono_images_storage_lock ();
+ 	MonoImageStorage *val = (MonoImageStorage *)g_hash_table_lookup (images_storage_hash, key);
++	if (val && !mono_refcount_tryinc (val)) {
++		// We raced against a mono_image_storage_dtor in progress.
++		val = NULL;
++	}
+ 	if (val) {
+-		mono_refcount_inc (val);
+ 		*found = val;
+ 		result = TRUE;
+ 	}
+diff --git a/mono/metadata/metadata.c b/mono/metadata/metadata.c
+index b2987016ef2..81217077470 100644
+--- a/mono/metadata/metadata.c
++++ b/mono/metadata/metadata.c
+@@ -2559,7 +2559,13 @@ retry:
+ 		return signature_in_image (type->data.method, image);
+ 	case MONO_TYPE_VAR:
+ 	case MONO_TYPE_MVAR:
+-		return image == mono_get_image_for_generic_param (type->data.generic_param);
++		if (image == mono_get_image_for_generic_param (type->data.generic_param))
++			return TRUE;
++		else if (type->data.generic_param->gshared_constraint) {
++			type = type->data.generic_param->gshared_constraint;
++			goto retry;
++		}
++		return FALSE;
+ 	default:
+ 		/* At this point, we should've avoided all potential allocations in mono_class_from_mono_type_internal () */
+ 		return image == m_class_get_image (mono_class_from_mono_type_internal (type));
+@@ -3037,13 +3043,16 @@ retry:
+ 		type = m_class_get_byval_arg (type->data.array->eklass);
+ 		goto retry;
+ 	case MONO_TYPE_FNPTR:
+-		//return signature_in_image (type->data.method, image);
+-		g_assert_not_reached ();
++		collect_signature_images (type->data.method, data);
++		break;
+ 	case MONO_TYPE_VAR:
+ 	case MONO_TYPE_MVAR:
+ 	{
+ 		MonoImage *image = mono_get_image_for_generic_param (type->data.generic_param);
+ 		add_image (image, data);
++		type = type->data.generic_param->gshared_constraint;
++		if (type)
++			goto retry;
+ 		break;
+ 	}
+ 	case MONO_TYPE_CLASS:
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0030-2020-02-linux-Some-pseudo-tty-fixes-21205.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0030-2020-02-linux-Some-pseudo-tty-fixes-21205.patch
@@ -1,0 +1,40 @@
+From a1ada04a58a69c792e0bb37021e98b9c0b0dc686 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Aleksey=20Kliger=20=28=CE=BBgeek=29?= <alklig@microsoft.com>
+Date: Mon, 30 Aug 2021 19:17:56 -0400
+Subject: [PATCH 30/32] [2020-02][linux] Some pseudo-tty fixes (#21205)
+
+* Ignore EINVAL errors on ioctl TIOCMGET/TIOCMSET so (#20219)
+
+pseudo-ttys are usable. (#20218)
+
+* Fix pseudo-ttys for kernel versions >= 5.13 (#21203)
+
+Co-authored-by: csanchezdll <csanchezdll@gmail.com>
+---
+ support/serial.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/support/serial.c b/support/serial.c
+index 74c54b0a21c..30542da9dd4 100644
+--- a/support/serial.c
++++ b/support/serial.c
+@@ -510,7 +510,15 @@ set_signal (int fd, MonoSerialSignal signal, gboolean value)
+ 
+ 	expected = get_signal_code (signal);
+ 	if (ioctl (fd, TIOCMGET, &signals) == -1)
+-		return -1;
++		{
++			/* Return successfully for pseudo-ttys.
++			 * Linux kernels < 5.13 return EINVAL,
++			 * but versions >=5.13 return ENOTTY. */
++			if (errno == EINVAL || errno == ENOTTY)
++				return 1;
++
++			return -1;
++		}
+ 	
+ 	activated = (signals & expected) != 0;
+ 	if (activated == value) /* Already set */
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0031-mini-Don-t-add-unbox-tramopline-on-generic-DIM-calls.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0031-mini-Don-t-add-unbox-tramopline-on-generic-DIM-calls.patch
@@ -1,0 +1,41 @@
+From 22074346900050843ace1d658cdb242f728a22fb Mon Sep 17 00:00:00 2001
+From: "github-actions[bot]"
+ <41898282+github-actions[bot]@users.noreply.github.com>
+Date: Fri, 3 Sep 2021 14:14:57 -0400
+Subject: [PATCH 31/32] [mini] Don't add unbox tramopline on generic DIM calls
+ (#21209)
+
+Don't unbox a valuetype `this` if the generic method is a DIM
+
+Fixes https://github.com/dotnet/runtime/issues/58394
+
+Fixes https://github.com/mono/mono/issues/21206
+
+Co-authored-by: lambdageek <lambdageek@users.noreply.github.com>
+---
+ mono/mini/mini-trampolines.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/mono/mini/mini-trampolines.c b/mono/mini/mini-trampolines.c
+index e5bb1cea2a2..3d507bfcc3d 100644
+--- a/mono/mini/mini-trampolines.c
++++ b/mono/mini/mini-trampolines.c
+@@ -637,11 +637,13 @@ common_call_trampoline (host_mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTa
+ 		return NULL;
+ 
+ 	if (generic_virtual || variant_iface) {
+-		if (m_class_is_valuetype (vt->klass)) /*FIXME is this required variant iface?*/
++		if (m_class_is_valuetype (vt->klass)  && !mini_method_is_default_method (m)) /*FIXME is this required variant iface?*/
+ 			need_unbox_tramp = TRUE;
+ 	} else if (orig_vtable_slot) {
+-		if (m_class_is_valuetype (m->klass))
++		if (m_class_is_valuetype (m->klass)) {
++			g_assert (!mini_method_is_default_method (m));
+ 			need_unbox_tramp = TRUE;
++		}
+ 	}
+ 
+ 	addr = mini_add_method_trampoline (m, compiled_method, need_rgctx_tramp, need_unbox_tramp);
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/0032-Ignore-inherit-param-for-ParameterInfo.GetCustomAttr.patch
+++ b/recipes-mono/mono/mono-6.12.0.154/0032-Ignore-inherit-param-for-ParameterInfo.GetCustomAttr.patch
@@ -1,0 +1,49 @@
+From 0c979e6d769bda97bfba41c29324f727e72e27d8 Mon Sep 17 00:00:00 2001
+From: "github-actions[bot]"
+ <41898282+github-actions[bot]@users.noreply.github.com>
+Date: Fri, 3 Sep 2021 14:16:00 -0400
+Subject: [PATCH 32/32] Ignore inherit param for
+ ParameterInfo.GetCustomAttributes (#21201)
+
+It is documented that the inherit flag is ignored.
+Attribute.GetCustomAttributes is to be used to search
+inheritance chain.
+
+This change is only for the Mono classlib implementation.
+CoreCLR already has this behavior.
+
+Co-authored-by: Bill Holmes <bill.holmes@unity3d.com>
+---
+ .../corlib/System.Reflection/RuntimeParameterInfo.cs   | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/mcs/class/corlib/System.Reflection/RuntimeParameterInfo.cs b/mcs/class/corlib/System.Reflection/RuntimeParameterInfo.cs
+index 0b49a1aff35..d57fbdecde9 100644
+--- a/mcs/class/corlib/System.Reflection/RuntimeParameterInfo.cs
++++ b/mcs/class/corlib/System.Reflection/RuntimeParameterInfo.cs
+@@ -192,14 +192,20 @@ public override
+ 		override
+ 		object[] GetCustomAttributes (bool inherit)
+ 		{
+-			return MonoCustomAttrs.GetCustomAttributes (this, inherit);
++			// It is documented that the inherit flag is ignored.
++			// Attribute.GetCustomAttributes is to be used to search
++			// inheritance chain.
++			return MonoCustomAttrs.GetCustomAttributes (this, false);
+ 		}
+ 
+ 		public
+ 		override
+ 		object[] GetCustomAttributes (Type attributeType, bool inherit)
+ 		{
+-			return MonoCustomAttrs.GetCustomAttributes (this, attributeType, inherit);
++			// It is documented that the inherit flag is ignored.
++			// Attribute.GetCustomAttributes is to be used to search
++			// inheritance chain.
++			return MonoCustomAttrs.GetCustomAttributes (this, attributeType, false);
+ 		}
+ 
+ 		internal object GetDefaultValueImpl (ParameterInfo pinfo)
+-- 
+2.31.1
+

--- a/recipes-mono/mono/mono-6.12.0.154/shm_open-test-crosscompile.diff
+++ b/recipes-mono/mono/mono-6.12.0.154/shm_open-test-crosscompile.diff
@@ -1,0 +1,12 @@
+--- mono-6.8.0.96/configure.ac.orig	2019-03-15 10:45:13.000000000 -0400
++++ mono-6.8.0.96/configure.ac	2019-03-19 08:00:53.815148109 -0400
+@@ -3264,6 +3264,9 @@
+ 			AC_DEFINE(HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP, 1, [shm_open that works well enough with mmap])
+ 		], [
+ 			AC_MSG_RESULT(no)
++		],[
++			AC_MSG_RESULT(yes)
++			AC_DEFINE(HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP, 1, [shm_open that works well enough with mmap])
+ 		])
+ 	fi
+ 

--- a/recipes-mono/mono/mono-native_6.12.0.147.bb
+++ b/recipes-mono/mono/mono-native_6.12.0.147.bb
@@ -3,11 +3,19 @@ require mono-mit-bsd-6xx.inc
 require mono-native-6.xx-base.inc
 require mono-${PV}.inc
 
-SRCREV = "mono-${PV}"
-
-SRC_URI = "git://github.com/mono/mono.git;protocol=https;branch=2020-02;destsuffix=mono-${PV} \
+SRC_URI = "http://download.mono-project.com/sources/mono/mono-${BASEPV}.tar.xz \
            file://0001-patch-XplatUIX11-cursor.diff \
            file://shm_open-test-crosscompile.diff \
+           file://0004-Disable-DebuggerTests.Crash-since-it-fails-on-Linux-.patch \
+           file://0007-Don-t-include-mono-dtrace.h-when-generating-offsets.patch \
+           file://0008-2020-02-marshal-Fix-VARIANT-and-BSTR-marshaling-in-s.patch \
+           file://0010-Fix-the-System.String.Replace-throwing-NotImplemente.patch \
+           file://0014-2020-02-Backport-r4-conv-i-fixes-20986.patch \
+           file://0016-arm64-Fix-wrong-marshalling-in-gsharedvt-transition-.patch \
+           file://0019-MonoIO-Wrap-calls-to-open-in-EINTR-handling-21042.patch \
+           file://0020-2020-02-Fix-leak-in-assembly-specific-dllmap-lookups.patch \
+           file://0024-2020-02-Start-a-dedicated-thread-for-MERP-crash-repo.patch \
+           file://0025-2020-02-Fix-memory-leak-during-data-registration-211.patch \
 "
 
 addtask fixup_config after do_patch before do_configure

--- a/recipes-mono/mono/mono-native_6.12.0.154.bb
+++ b/recipes-mono/mono/mono-native_6.12.0.154.bb
@@ -1,0 +1,34 @@
+require mono-6.xx.inc
+require mono-mit-bsd-6xx.inc
+require mono-native-6.xx-base.inc
+require mono-${PV}.inc
+
+SRC_URI = "http://download.mono-project.com/sources/mono/mono-${BASEPV}.tar.xz \
+           file://0001-patch-XplatUIX11-cursor.diff \
+           file://shm_open-test-crosscompile.diff \
+           file://0004-Disable-DebuggerTests.Crash-since-it-fails-on-Linux-.patch \
+           file://0007-Don-t-include-mono-dtrace.h-when-generating-offsets.patch \
+           file://0008-2020-02-marshal-Fix-VARIANT-and-BSTR-marshaling-in-s.patch \
+           file://0010-Fix-the-System.String.Replace-throwing-NotImplemente.patch \
+           file://0014-2020-02-Backport-r4-conv-i-fixes-20986.patch \
+           file://0016-arm64-Fix-wrong-marshalling-in-gsharedvt-transition-.patch \
+           file://0019-MonoIO-Wrap-calls-to-open-in-EINTR-handling-21042.patch \
+           file://0020-2020-02-Fix-leak-in-assembly-specific-dllmap-lookups.patch \
+           file://0024-2020-02-Start-a-dedicated-thread-for-MERP-crash-repo.patch \
+           file://0025-2020-02-Fix-memory-leak-during-data-registration-211.patch \
+           file://0026-mini-Add-GC-Unsafe-transitions-in-mono_pmip-21186.patch \
+           file://0027-Adding-null-check-to-avoid-abort-when-invalid-IL-is-.patch \
+           file://0028-Mono.Profiler.Aot-Write-true-string-wire-length-2119.patch \
+           file://0029-2020-02-backport-metadata-fixes-21190.patch \
+           file://0030-2020-02-linux-Some-pseudo-tty-fixes-21205.patch \
+           file://0031-mini-Don-t-add-unbox-tramopline-on-generic-DIM-calls.patch \
+           file://0032-Ignore-inherit-param-for-ParameterInfo.GetCustomAttr.patch \
+"
+
+addtask fixup_config after do_patch before do_configure
+
+do_fixup_config() {
+        sed 's|$mono_libdir/libMonoPosixHelper@libsuffix@|libMonoPosixHelper.so|g' -i ${S}/data/config.in
+        sed 's|@X11@|libX11.so.6|g' -i ${S}/data/config.in
+        sed 's|@libgdiplus_install_loc@|libgdiplus.so.0|g' -i ${S}/data/config.in
+}

--- a/recipes-mono/mono/mono_6.12.0.147.bb
+++ b/recipes-mono/mono/mono_6.12.0.147.bb
@@ -5,10 +5,18 @@ require mono-${PV}.inc
 
 RDEPENDS:${PN}-dev =+ " zlib "
 
-SRCREV = "mono-${PV}"
-
-SRC_URI = "git://github.com/mono/mono.git;protocol=https;branch=2020-02;destsuffix=mono-${PV} \
+SRC_URI = "http://download.mono-project.com/sources/mono/mono-${BASEPV}.tar.xz \
            file://shm_open-test-crosscompile.diff \
+           file://0004-Disable-DebuggerTests.Crash-since-it-fails-on-Linux-.patch \
+           file://0007-Don-t-include-mono-dtrace.h-when-generating-offsets.patch \
+           file://0008-2020-02-marshal-Fix-VARIANT-and-BSTR-marshaling-in-s.patch \
+           file://0010-Fix-the-System.String.Replace-throwing-NotImplemente.patch \
+           file://0014-2020-02-Backport-r4-conv-i-fixes-20986.patch \
+           file://0016-arm64-Fix-wrong-marshalling-in-gsharedvt-transition-.patch \
+           file://0019-MonoIO-Wrap-calls-to-open-in-EINTR-handling-21042.patch \
+           file://0020-2020-02-Fix-leak-in-assembly-specific-dllmap-lookups.patch \
+           file://0024-2020-02-Start-a-dedicated-thread-for-MERP-crash-repo.patch \
+           file://0025-2020-02-Fix-memory-leak-during-data-registration-211.patch \
 "
 
 

--- a/recipes-mono/mono/mono_6.12.0.154.bb
+++ b/recipes-mono/mono/mono_6.12.0.154.bb
@@ -1,0 +1,41 @@
+require mono-6.xx.inc
+require mono-mit-bsd-6xx.inc
+require ${PN}-base.inc
+require mono-${PV}.inc
+
+RDEPENDS:${PN}-dev =+ " zlib "
+
+SRC_URI = "http://download.mono-project.com/sources/mono/mono-${BASEPV}.tar.xz \
+           file://shm_open-test-crosscompile.diff \
+           file://0004-Disable-DebuggerTests.Crash-since-it-fails-on-Linux-.patch \
+           file://0007-Don-t-include-mono-dtrace.h-when-generating-offsets.patch \
+           file://0008-2020-02-marshal-Fix-VARIANT-and-BSTR-marshaling-in-s.patch \
+           file://0010-Fix-the-System.String.Replace-throwing-NotImplemente.patch \
+           file://0014-2020-02-Backport-r4-conv-i-fixes-20986.patch \
+           file://0016-arm64-Fix-wrong-marshalling-in-gsharedvt-transition-.patch \
+           file://0019-MonoIO-Wrap-calls-to-open-in-EINTR-handling-21042.patch \
+           file://0020-2020-02-Fix-leak-in-assembly-specific-dllmap-lookups.patch \
+           file://0024-2020-02-Start-a-dedicated-thread-for-MERP-crash-repo.patch \
+           file://0025-2020-02-Fix-memory-leak-during-data-registration-211.patch \
+           file://0026-mini-Add-GC-Unsafe-transitions-in-mono_pmip-21186.patch \
+           file://0027-Adding-null-check-to-avoid-abort-when-invalid-IL-is-.patch \
+           file://0028-Mono.Profiler.Aot-Write-true-string-wire-length-2119.patch \
+           file://0029-2020-02-backport-metadata-fixes-21190.patch \
+           file://0030-2020-02-linux-Some-pseudo-tty-fixes-21205.patch \
+           file://0031-mini-Don-t-add-unbox-tramopline-on-generic-DIM-calls.patch \
+           file://0032-Ignore-inherit-param-for-ParameterInfo.GetCustomAttr.patch \
+"
+
+
+addtask fixup_config after do_patch before do_configure
+
+do_fixup_config() {
+        sed 's|$mono_libdir/libMonoPosixHelper@libsuffix@|libMonoPosixHelper.so|g' -i ${S}/data/config.in
+        sed 's|@X11@|libX11.so.6|g' -i ${S}/data/config.in
+        sed 's|@libgdiplus_install_loc@|libgdiplus.so.0|g' -i ${S}/data/config.in
+}
+
+PACKAGES += "${PN}-profiler "
+FILES:${PN}-profiler += " ${datadir}/mono-2.0/mono/profiler/*"
+
+INSANE_SKIP:${PN}-libs += "dev-so"


### PR DESCRIPTION
Building mono from git doesn't work properly. Our projects fail to build because mscorlib is missing for many API versions.
Use the 6.12.0.122 stable release tarball and add most of the patches from github. This way we can built our projects.
6.12.0.154 contains an important fix for Linux kernel 5.13+.