### PR TITLE
msbuild-libhostfxr: Upgrade to 3.1.16

### DIFF
--- a/recipes-mono/msbuild/msbuild-libhostfxr_3.1.16.bb
+++ b/recipes-mono/msbuild/msbuild-libhostfxr_3.1.16.bb
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/dotnet/core-setup.git;branch=release/3.1 \
            file://0001-Don-t-set-a-plethora-of-compiler-arguments-through-c.patch;patchdir=${WORKDIR}/git \
            file://0002-Remove-broken-objcopy-detection-STRIP_SYMBOLS-is-uns.patch;patchdir=${WORKDIR}/git \
            "
-SRCREV = "f5eceb810586ea6138aadcef9e2bba115015ab99"
+SRCREV = "4c6b4aa257241c4d419b8c271e37afac4445b1c0"
 
 inherit cmake
 


### PR DESCRIPTION
3.1.11 was hitting this compile error on Fedora 34 with GCC 11
as the host compiler:

| .../3.1.11-r0/git/src/corehost/cli/test/nativehost/host_context_test.cpp: In function ‘void {anonymous}::wait_for_signal_mock_execute_assembly()’:
| .../3.1.11-r0/git/src/corehost/cli/test/nativehost/host_context_test.cpp:436:31: error: ‘sleep_for’ is not a member of ‘std::this_thread’
|   436 |             std::this_thread::sleep_for(std::chrono::milliseconds(100));
|       |                               ^~~~~~~~~

This was fixed in commit a49e99c5517054c2fa8a6772ce028acf56dfc54c
("Fix build errors using GCC 11 (#46334) (#9136)") which is in 3.1.16

The current set of patches still apply to 3.1.16 but not newer.

Signed-off-by: Zoltán Böszörményi <zboszor@gmail.com>