### PR TITLE
Fix SRC_URI warnings

### DIFF
--- a/recipes-mono/msbuild/msbuild-libhostfxr_3.1.16.bb
+++ b/recipes-mono/msbuild/msbuild-libhostfxr_3.1.16.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE.TXT;md5=9fc642ff452b28d62ab19b
 
 COMPATIBLE_HOST ?= "(i.86|x86_64|arm|aarch64).*-linux"
 
-SRC_URI = "git://github.com/dotnet/core-setup.git;branch=release/3.1 \
+SRC_URI = "git://github.com/dotnet/core-setup.git;branch=release/3.1;protocol=https \
            file://0001-Don-t-set-a-plethora-of-compiler-arguments-through-c.patch;patchdir=${WORKDIR}/git \
            file://0002-Remove-broken-objcopy-detection-STRIP_SYMBOLS-is-uns.patch;patchdir=${WORKDIR}/git \
            "

--- a/recipes-mono/msbuild/msbuild_16.6.bb
+++ b/recipes-mono/msbuild/msbuild_16.6.bb
@@ -14,7 +14,7 @@ inherit mono
 
 SRCREV = "94d0c55bc96f297618d50cc32167ddba9fee30b0"
 
-SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git;branch=main \
+SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git;branch=main;protocol=https \
            file://mono-msbuild-dotnetbits-case.patch \
            file://mono-msbuild-license-case.patch \
            file://mono-msbuild-no-hostfxr.patch \


### PR DESCRIPTION
From the first commit:
```
Use protocol=https for git://github.com/...

GitHub will remove the unauthenticated git protocol in favour of
the (still anonymous) https protocol and they even exercised a
short brownout period.

Yocto/Bitbake started printing warnings about this.
```