### PR TITLE
Update libgdiplus-6.xx.inc

### DIFF
--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-test:
     runs-on: [self-hosted, linux]
     container:
-      image: dynamicdevices/yocto-ci-build:latest
+      image: dynamicdevices/yocto-ci-build:x86
       options: --privileged -v /dev/net/tun:/dev/net/tun -v /dev/kvm:/dev/kvm
     strategy:
       matrix:

--- a/recipes-mono/libgdiplus/libgdiplus-6.xx.inc
+++ b/recipes-mono/libgdiplus/libgdiplus-6.xx.inc
@@ -1,9 +1,9 @@
-PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} jpeg tiff gif exif pango"
+PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} jpeg tiff gif exif"
 PACKAGECONFIG[jpeg] = "--with-libjpeg,--without-libjpeg,jpeg"
 PACKAGECONFIG[tiff] = "--with-libtiff,--without-libtiff,tiff"
 PACKAGECONFIG[gif] = "--with-libgif,--without-libgif,giflib"
 PACKAGECONFIG[exif] = "--with-libexif,--without-libexif,libexif"
-PACKAGECONFIG[pango] = "--with-pango,--without-pango,pango"
+PACKAGECONFIG[pango] = "--with-pango,,pango"
 PACKAGECONFIG[x11] = ",--without-x11,virtual/libx11 libxft"
 
 DEPENDS =+ "cairo freetype fontconfig libpng"

--- a/recipes-mono/libgdiplus/libgdiplus.inc
+++ b/recipes-mono/libgdiplus/libgdiplus.inc
@@ -5,7 +5,7 @@ PACKAGECONFIG[gif] = "--with-libgif,--without-libgif,giflib"
 PACKAGECONFIG[exif] = "--with-libexif,--without-libexif,libexif"
 PACKAGECONFIG[x11] = "--with-x11,--without-x11,virtual/libx11 libxft"
 
-DEPENDS =+ "cairo freetype fontconfig libpng"
+DEPENDS =+ "cairo-dev freetype fontconfig libpng"
 
 do_install:append() {
 # fix pkgconfig .pc file


### PR DESCRIPTION
Disable Pango support, as it doesn't seem to properly measure the cursor size and draws a too big cursor

As discussed in https://github.com/DynamicDevices/meta-mono/issues/105