### PR TITLE
Disabled pango support as it breaks cursor measurement.

### DIFF
--- a/recipes-mono/libgdiplus/libgdiplus-6.xx.inc
+++ b/recipes-mono/libgdiplus/libgdiplus-6.xx.inc
@@ -1,9 +1,9 @@
-PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} jpeg tiff gif exif pango"
+PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} jpeg tiff gif exif"
 PACKAGECONFIG[jpeg] = "--with-libjpeg,--without-libjpeg,jpeg"
 PACKAGECONFIG[tiff] = "--with-libtiff,--without-libtiff,tiff"
 PACKAGECONFIG[gif] = "--with-libgif,--without-libgif,giflib"
 PACKAGECONFIG[exif] = "--with-libexif,--without-libexif,libexif"
-PACKAGECONFIG[pango] = "--with-pango,--without-pango,pango"
+PACKAGECONFIG[pango] = "--with-pango,,pango"
 PACKAGECONFIG[x11] = ",--without-x11,virtual/libx11 libxft"
 
 DEPENDS =+ "cairo freetype fontconfig libpng"

--- a/recipes-mono/libgdiplus/libgdiplus_6.0.4.bb
+++ b/recipes-mono/libgdiplus/libgdiplus_6.0.4.bb
@@ -5,7 +5,6 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=e0a7dacaa67d7e24a32074fba736dc59"
 
 SRC_URI += " \
 		file://0001-fix-cross-compile.patch \
-		file://0001-configure-Fix-build-with-Gentoo-pango.patch \
 		"
 
 SRC_URI[md5sum] = "3f94b3d61934eecccaaac5a49501b283"

--- a/recipes-mono/libgdiplus/libgdiplus_6.0.5.bb
+++ b/recipes-mono/libgdiplus/libgdiplus_6.0.5.bb
@@ -5,7 +5,6 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=e0a7dacaa67d7e24a32074fba736dc59"
 
 SRC_URI += " \
 		file://0001-fix-cross-compile.patch \
-		file://0001-configure-Fix-build-with-Gentoo-pango.patch \
 		"
 
 SRC_URI[md5sum] = "8079300e708c7ea9b4254d4b2eeba463"


### PR DESCRIPTION
Disabled  pango support as it breaks cursor measurement.

See; https://github.com/DynamicDevices/meta-mono/issues/105