### PR TITLE
dotnet: Revert to old pre-honister override syntax

### DIFF
--- a/recipes-mono/dotnet/dotnet_5.0.300.bb
+++ b/recipes-mono/dotnet/dotnet_5.0.300.bb
@@ -7,28 +7,28 @@ COMPATIBLE_HOST ?= "(x86_64|aarch64|arm).*-linux"
 
 DEPENDS = "zlib"
 
-RDEPENDS:${PN} = "\
+RDEPENDS_${PN} = "\
     icu \
     libgssapi-krb5 \
     lttng-ust \
     zlib \
 "
 
-RDEPENDS:${PN}:remove:class-native = "libgssapi-krb5 lttng-ust"
+RDEPENDS_${PN}_remove_class-native = "libgssapi-krb5 lttng-ust"
 
 PR = "r0"
 
-SRC_ARCH:aarch64 = "arm64"
-SRC_FETCH_ID:aarch64 = "50c2990a-2b62-4a51-b3db-8dab334f81c9/e0edfb3905b31ab030a97fa64f48cc8e"
-SRC_SHA512SUM:aarch64 = "654e625627b35d9b8e4e5967c76485d0ff91769f5bb5429c99e0554c601426de1b26a5c37d32ab4bc227a15409c134757d5422944cf52c945b351c5927a28393"
+SRC_ARCH_aarch64 = "arm64"
+SRC_FETCH_ID_aarch64 = "50c2990a-2b62-4a51-b3db-8dab334f81c9/e0edfb3905b31ab030a97fa64f48cc8e"
+SRC_SHA512SUM_aarch64 = "654e625627b35d9b8e4e5967c76485d0ff91769f5bb5429c99e0554c601426de1b26a5c37d32ab4bc227a15409c134757d5422944cf52c945b351c5927a28393"
 
-SRC_ARCH:arm = "arm"
-SRC_FETCH_ID:arm = "4bbb3a8d-e32a-4822-81d8-b2c570414f0a/aa7659eac0f0c52316a0fa7aa7c2081a"
-SRC_SHA512SUM:arm = "9e507eac7d6598188766d6281ee8102c8f2b738611a4050cc7cbce7723591dce4b6e8d35588561741852f46a6f9af4fd4b715c328007a461cc5fb468d7ab0d8c"
+SRC_ARCH_arm = "arm"
+SRC_FETCH_ID_arm = "4bbb3a8d-e32a-4822-81d8-b2c570414f0a/aa7659eac0f0c52316a0fa7aa7c2081a"
+SRC_SHA512SUM_arm = "9e507eac7d6598188766d6281ee8102c8f2b738611a4050cc7cbce7723591dce4b6e8d35588561741852f46a6f9af4fd4b715c328007a461cc5fb468d7ab0d8c"
 
-SRC_ARCH:x86-64 = "x64"
-SRC_FETCH_ID:x86-64 = "98563846-f949-4dc7-81a0-77016735bf08/56d5882a2046382fccb7db032f7d2a02"
-SRC_SHA512SUM:x86-64 = "724a8e6ed77d2d3b957b8e5eda82ca8c99152d8691d1779b4a637d9ff781775f983468ee46b0bc8ad0ddbfd9d537dd8decb6784f43edae72c9529a90767310d2"
+SRC_ARCH_x86-64 = "x64"
+SRC_FETCH_ID_x86-64 = "98563846-f949-4dc7-81a0-77016735bf08/56d5882a2046382fccb7db032f7d2a02"
+SRC_SHA512SUM_x86-64 = "724a8e6ed77d2d3b957b8e5eda82ca8c99152d8691d1779b4a637d9ff781775f983468ee46b0bc8ad0ddbfd9d537dd8decb6784f43edae72c9529a90767310d2"
 
 SRC_URI[vardeps] += "SRC_FETCH_ID SRC_ARCH"
 SRC_URI[sha512sum] = "${SRC_SHA512SUM}"
@@ -64,24 +64,24 @@ do_install() {
     cp -r --no-preserve=ownership ${S}/shared/Microsoft.AspNetCore.App/${RUNTIME} ${D}${datadir}/dotnet/shared/Microsoft.AspNetCore.App
 }
 
-FILES:${PN} += "\
+FILES_${PN} += "\
     ${datadir}/dotnet/dotnet \
     ${datadir}/dotnet/*.txt \
     ${datadir}/dotnet/host \
     ${datadir}/dotnet/shared \
 "
 
-FILES:${PN}-dev = "\
+FILES_${PN}-dev = "\
     ${datadir}/dotnet/sdk \
     ${datadir}/dotnet/templates \
 "
 
-FILES:${PN}-dbg = "\
+FILES_${PN}-dbg = "\
     ${datadir}/dotnet/.debug \
 "
 
-RRECOMMENDS:dotnet-dev[nodeprrecs] = "1"
+RRECOMMENDS_dotnet-dev[nodeprrecs] = "1"
 
-INSANE_SKIP:${PN} = "already-stripped libdir staticdev textrel"
+INSANE_SKIP_${PN} = "already-stripped libdir staticdev textrel"
 
 BBCLASSEXTEND = "native"

--- a/recipes-mono/images/test-image-mono.bb
+++ b/recipes-mono/images/test-image-mono.bb
@@ -3,8 +3,8 @@ require recipes-sato/images/core-image-sato.bb
 require core-image-mono.inc
 
 # Build up meta-mono test image here
-#IMAGE_INSTALL += "msbuild \
-#"
+IMAGE_INSTALL += " dotnet \
+"
 
 IMAGE_BASENAME = "${PN}"
 


### PR DESCRIPTION
Yocto changed the override syntax in Yocto honister (3.4). This was
introduced somehow in the dotnet recipe of the dunfell branch of
meta-mono.
Probably from https://github.com/intel-iot-devkit/meta-iot-cloud/blob/08d0c505097b889836315a4fe9b41acbb264be3f/recipes-devtools/dotnet/dotnet_5.0.300.bb

The error looks like this:
```
ERROR: ParseError at .../meta-mono/recipes-mono/dotnet/dotnet_5.0.300.bb:15: unparsed line: 'RDEPENDS:${PN} = "    icu     libgssapi-krb5     lttng-ust     zlib "'
```

Revert the changes back to the plain old Yocto override syntax.