### PR TITLE
dotnet: update to v6.0.7

### DIFF
--- a/recipes-mono/dotnet/dotnet_6.0.302.bb
+++ b/recipes-mono/dotnet/dotnet_6.0.302.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=9fc642ff452b28d62ab19b7eea50dfb9"
 
 COMPATIBLE_HOST ?= "(x86_64|aarch64|arm).*-linux"
 
-DEPENDS = "zlib"
+DEPENDS = "patchelf-native"
 
 #FIXME add lttng-ust as soon as dotnet core supports liblttng-ust.so.1
 RDEPENDS:${PN} = "\
@@ -19,16 +19,16 @@ RDEPENDS:${PN}:remove:class-native = "libgssapi-krb5"
 PR = "r0"
 
 SRC_ARCH:aarch64 = "arm64"
-SRC_FETCH_ID:aarch64 = "952f5525-7227-496f-85e5-09cadfb44629/eefd0f6eb8f809bfaf4f0661809ed826"
-SRC_SHA512SUM:aarch64 = "2d0021bb4cd221ffba6888dbd6300e459f45f4f9d3cf7323f3b97ee0f093ef678f5a36d1c982296f4e15bbcbd7275ced72c3e9b2fc754039ba663d0612ffd866"
+SRC_FETCH_ID:aarch64 = "33389348-a7d7-41ae-850f-ec46d3ca9612/36bad11f948b05a4fa9faac93c35e574"
+SRC_SHA512SUM:aarch64 = "26e98a63665d707b1a7729f1794077316f9927edd88d12d82d0357fe597096b0d89b64a085fcdf0cf49807a443bbfebb48e10ea91cea890846cf4308e67c4ea5"
 
 SRC_ARCH:arm = "arm"
-SRC_FETCH_ID:arm = "e41a177d-9f0b-4afe-97a4-53587cd89d00/c2c897aa6442d49c1d2d86abb23c20b2"
-SRC_SHA512SUM:arm = "8c2d56256f4bebe58caee7810b7689408ff023b1f2e68f99fa375f0115db41ef0c3eb160b9ab84dc2764443a045801a4b03f6bc9090e0c1583fca2587ea0d9d6"
+SRC_FETCH_ID:arm = "f35557f7-d5e1-43be-93b6-e59ee8bd823c/9dd2c25a4d7351412ff5902c355732ca"
+SRC_SHA512SUM:arm = "0d31c7e8ccf02c8dea92d7b60bcb15e15912d74e7ee2ab8fd88ee03c4fbd8f292c356357d08ec23c2aedc5e3e0803d42ce16f3fff36245739d0cac6634bc3387"
 
 SRC_ARCH:x86-64 = "x64"
-SRC_FETCH_ID:x86-64 = "9d8c7137-2091-4fc6-a419-60ba59c8b9de/db0c5cda94f31d2260d369123de32d59"
-SRC_SHA512SUM:x86-64 = "81e9c368d445d9e92e3af471d52dc2aa05e3ecb75ce95c13a2ed1d117852dae43d23d913bbe92eab730aef7f38a14488a1ac65c3b79444026a629647322c5798"
+SRC_FETCH_ID:x86-64 = "0e83f50a-0619-45e6-8f16-dc4f41d1bb16/e0de908b2f070ef9e7e3b6ddea9d268c"
+SRC_SHA512SUM:x86-64 = "ac1d124802ca035aa00806312460b371af8e3a55d85383ddd8bb66f427c4fabae75b8be23c45888344e13b283a4f9c7df228447c06d796a57ffa5bb21992e6a4"
 
 SRC_URI[vardeps] += "SRC_FETCH_ID SRC_ARCH"
 SRC_URI[sha512sum] = "${SRC_SHA512SUM}"
@@ -38,8 +38,8 @@ SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/${SRC_FETCH_I
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 
-RUNTIME = "6.0.4"
-do_install[vardeps] += "RUNTIME"
+DOTNET_RUNTIME = "6.0.7"
+do_install[vardeps] += "DOTNET_RUNTIME"
 
 do_install() {
     install -d ${D}${bindir}
@@ -52,28 +52,27 @@ do_install() {
     install -m 0644 ${S}/ThirdPartyNotices.txt ${D}${datadir}/dotnet
 
     install -d ${D}${datadir}/dotnet/host/fxr
-    cp -r --no-preserve=ownership ${S}/host/fxr/${RUNTIME} ${D}${datadir}/dotnet/host/fxr
+    cp -r --no-preserve=ownership ${S}/host/fxr/${DOTNET_RUNTIME} ${D}${datadir}/dotnet/host/fxr
 
     cp -r --no-preserve=ownership ${S}/sdk ${D}${datadir}/dotnet/
     cp -r --no-preserve=ownership ${S}/sdk-manifests ${D}${datadir}/dotnet/
 
     install -d ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App
-    cp -r --no-preserve=ownership ${S}/shared/Microsoft.NETCore.App/${RUNTIME} ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App
-
-    #FIXME: remove the following line. if the lttng-ust conflict is solved
-    rm ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App/${RUNTIME}/libcoreclrtraceptprovider.so
+    cp -r --no-preserve=ownership ${S}/shared/Microsoft.NETCore.App/${DOTNET_RUNTIME} ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App
 
     install -d ${D}${datadir}/dotnet/shared/Microsoft.AspNetCore.App
-    cp -r --no-preserve=ownership ${S}/shared/Microsoft.AspNetCore.App/${RUNTIME} ${D}${datadir}/dotnet/shared/Microsoft.AspNetCore.App
+    cp -r --no-preserve=ownership ${S}/shared/Microsoft.AspNetCore.App/${DOTNET_RUNTIME} ${D}${datadir}/dotnet/shared/Microsoft.AspNetCore.App
 
-    if [ "${SRC_ARCH}" = "x64" ]; then
-        ln -s ${base_libdir} ${D}/lib64
-    fi
+    # Hack to fix liblttng-ust dependency issues
+    patchelf --remove-needed liblttng-ust.so.0 ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App/${DOTNET_RUNTIME}/libcoreclrtraceptprovider.so
+}
 
+do_install:append:x86-64() {
+    # Set correct interpreter path
+    patchelf --set-interpreter ${base_libdir}/ld-linux-x86-64.so.2 ${D}${datadir}/dotnet/dotnet
 }
 
 FILES:${PN} += "\
-    /lib64 \
     ${datadir}/dotnet/dotnet \
     ${datadir}/dotnet/*.txt \
     ${datadir}/dotnet/host \


### PR DESCRIPTION
- update the dotnet6 recipes
- patch the library to not use liblttng-ust instead of deleting
it completely
- for x86 correct the interpreter path instead of creating a link

Signed-off-by: Ben Fekih, Hichem <hichem.f@live.de>