### PR TITLE
dotnet: update to v6.0.11

### DIFF
--- a/recipes-mono/dotnet/dotnet_6.0.403.bb
+++ b/recipes-mono/dotnet/dotnet_6.0.403.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=9fc642ff452b28d62ab19b7eea50dfb9"
 
 COMPATIBLE_HOST ?= "(x86_64|aarch64|arm).*-linux"
 
-DEPENDS = "zlib"
+DEPENDS = "patchelf-native"
 
 #FIXME add lttng-ust as soon as dotnet core supports liblttng-ust.so.1
 RDEPENDS:${PN} = "\
@@ -19,16 +19,16 @@ RDEPENDS:${PN}:remove:class-native = "libgssapi-krb5"
 PR = "r0"
 
 SRC_ARCH:aarch64 = "arm64"
-SRC_FETCH_ID:aarch64 = "952f5525-7227-496f-85e5-09cadfb44629/eefd0f6eb8f809bfaf4f0661809ed826"
-SRC_SHA512SUM:aarch64 = "2d0021bb4cd221ffba6888dbd6300e459f45f4f9d3cf7323f3b97ee0f093ef678f5a36d1c982296f4e15bbcbd7275ced72c3e9b2fc754039ba663d0612ffd866"
+SRC_FETCH_ID:aarch64 = "67ca3f83-3769-4cd8-882a-27ab0c191784/bf631a0229827de92f5c026055218cc0"
+SRC_SHA512SUM:aarch64 = "fe62f6eca80acb6774f0a80c472dd02851d88f7ec09cc7f1cadd9981ec0ee1ceb87224911fc0c544cb932c7f5a91c66471a0458b50f85c899154bc8c3605a88e"
 
 SRC_ARCH:arm = "arm"
-SRC_FETCH_ID:arm = "e41a177d-9f0b-4afe-97a4-53587cd89d00/c2c897aa6442d49c1d2d86abb23c20b2"
-SRC_SHA512SUM:arm = "8c2d56256f4bebe58caee7810b7689408ff023b1f2e68f99fa375f0115db41ef0c3eb160b9ab84dc2764443a045801a4b03f6bc9090e0c1583fca2587ea0d9d6"
+SRC_FETCH_ID:arm = "10cadabb-4cb4-4cca-94db-67cb31cb6f3a/5b3d102b4198da0a25ed12d83ae5633d"
+SRC_SHA512SUM:arm = "b07423700a92e3cc79f4e9e02c40e923352c09958e3307fd2ce7fc882509460c65a4404e8080f1b3852af98458512699ba43b37683916756666b4e2532cc8f46"
 
 SRC_ARCH:x86-64 = "x64"
-SRC_FETCH_ID:x86-64 = "9d8c7137-2091-4fc6-a419-60ba59c8b9de/db0c5cda94f31d2260d369123de32d59"
-SRC_SHA512SUM:x86-64 = "81e9c368d445d9e92e3af471d52dc2aa05e3ecb75ce95c13a2ed1d117852dae43d23d913bbe92eab730aef7f38a14488a1ac65c3b79444026a629647322c5798"
+SRC_FETCH_ID:x86-64 = "1d2007d3-da35-48ad-80cc-a39cbc726908/1f3555baa8b14c3327bb4eaa570d7d07"
+SRC_SHA512SUM:x86-64 = "779b3e24a889dbb517e5ff5359dab45dd3296160e4cb5592e6e41ea15cbf87279f08405febf07517aa02351f953b603e59648550a096eefcb0a20fdaf03fadde"
 
 SRC_URI[vardeps] += "SRC_FETCH_ID SRC_ARCH"
 SRC_URI[sha512sum] = "${SRC_SHA512SUM}"
@@ -38,7 +38,7 @@ SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/${SRC_FETCH_I
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 
-DOTNET_RUNTIME = "6.0.4"
+DOTNET_RUNTIME = "6.0.11"
 do_install[vardeps] += "DOTNET_RUNTIME"
 
 do_install() {
@@ -60,20 +60,19 @@ do_install() {
     install -d ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App
     cp -r --no-preserve=ownership ${S}/shared/Microsoft.NETCore.App/${DOTNET_RUNTIME} ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App
 
-    #FIXME: remove the following line. if the lttng-ust conflict is solved
-    rm ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App/${DOTNET_RUNTIME}/libcoreclrtraceptprovider.so
-
     install -d ${D}${datadir}/dotnet/shared/Microsoft.AspNetCore.App
     cp -r --no-preserve=ownership ${S}/shared/Microsoft.AspNetCore.App/${DOTNET_RUNTIME} ${D}${datadir}/dotnet/shared/Microsoft.AspNetCore.App
 
-    if [ "${SRC_ARCH}" = "x64" ]; then
-        ln -s ${base_libdir} ${D}/lib64
-    fi
+    # Hack to fix liblttng-ust dependency issues
+    patchelf --remove-needed liblttng-ust.so.0 ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App/${DOTNET_RUNTIME}/libcoreclrtraceptprovider.so
+}
 
+do_install:append:x86-64() {
+    # Set correct interpreter path
+    patchelf --set-interpreter ${base_libdir}/ld-linux-x86-64.so.2 ${D}${datadir}/dotnet/dotnet
 }
 
 FILES:${PN} += "\
-    /lib64 \
     ${datadir}/dotnet/dotnet \
     ${datadir}/dotnet/*.txt \
     ${datadir}/dotnet/host \


### PR DESCRIPTION
- update the dotnet6 recipes to v6.0.11 and backport some further pathces from master
- patch the library to not use liblttng-ust instead of deleting it completely
- for x86 correct the interpreter path instead of creating a link