### PR TITLE
msbuild: Depend on curl-native and ca-certificates-native

### DIFF
--- a/recipes-mono/msbuild/msbuild_16.6.bb
+++ b/recipes-mono/msbuild/msbuild_16.6.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://docs.microsoft.com/visualstudio/msbuild/msbuild"
 SECTION = "console/apps"
 LICENSE = "MIT"
 
-DEPENDS = "unzip-native msbuild-libhostfxr-native"
+DEPENDS = "curl-native ca-certificates-native unzip-native msbuild-libhostfxr-native"
 
 RDEPENDS:${PN} = "msbuild-libhostfxr"
 


### PR DESCRIPTION
This fixes the download error and the subsequent build errors:
```
| DEBUG: Executing shell function do_compile
| ** Downloading MSBUILD from https://github.com/mono/msbuild/releases/download/0.08/mono_msbuild_6.4.0.208.zip 
| ./eng/cibuild_bootstrapped_msbuild.sh: line 59: curl: command not found 
| unzip:  cannot find or open .../msbuild-native/16.6-r0/git/eng/../artifacts/msbuild.zip,
  .../msbuild-native/16.6-r0/git/eng/../artifacts/msbuild.zip.zip or
  .../msbuild-native/16.6-r0/git/eng/../artifacts/msbuild.zip.ZIP.
```