### PR TITLE
RFC: Build mono and mono-native 6.xx with -O1

### DIFF
--- a/recipes-mono/mono/mono-6.xx.inc
+++ b/recipes-mono/mono/mono-6.xx.inc
@@ -35,6 +35,10 @@ inherit python3native
 # avoids build breaks when using no-static-libs.inc
 DISABLE_STATIC = ""
 
+# Fedora builds Mono with -O1, maybe for a reason
+BUILD_OPTIMIZATION = "-O1 -pipe"
+FULL_OPTIMIZATION = "-O1 -pipe ${DEBUG_FLAGS}"
+
 EXTRA_OECONF += " mono_cv_uscore=no --with-sigaltstack=no --with-mcs-docs=no "
 
 do_configure:prepend() {


### PR DESCRIPTION
Not for merging, just consideration.

Both settings are needed to be set for the recipes get built with `-O1`