### PR TITLE
Fix mmap segfault on recent kernels

### DIFF
--- a/recipes-mono/mono/mono-6.12.0.161/disable-mmap-MAP_32BIT-support.patch
+++ b/recipes-mono/mono/mono-6.12.0.161/disable-mmap-MAP_32BIT-support.patch
@@ -1,0 +1,47 @@
+From e019d4ac4735e774d0a3c15bb36d5eb3ebfa3053 Mon Sep 17 00:00:00 2001
+From: Raphael Robatsch <raphael-git@tapesoftware.net>
+Date: Tue, 9 May 2023 11:55:02 +0200
+Subject: [PATCH] Disable mmap(MAP_32BIT) support
+
+mmap(2) with flag MAP_32BIT can erroneously return ENOMEM on recent
+kernels. Disable MAP_32BIT support for now.
+
+Reference: https://lore.kernel.org/linux-mm/cb8dc31a-fef2-1d09-f133-e9f7b9f9e77a@sony.com/
+Reference: https://lore.kernel.org/all/20230414185919.4175572-1-Liam.Howlett@oracle.com/T/#m00a0ac8a72bf2f26711b7f8cc56612a8ef62c3d0
+---
+ mono/mini/mini-amd64.h    | 2 --
+ mono/utils/mono-codeman.c | 4 ----
+ 2 files changed, 6 deletions(-)
+
+diff --git a/mono/mini/mini-amd64.h b/mono/mini/mini-amd64.h
+index b321743b67d..0a81bb4bd6b 100644
+--- a/mono/mini/mini-amd64.h
++++ b/mono/mini/mini-amd64.h
+@@ -390,9 +390,7 @@
+ 
+ #endif /* !HOST_WIN32 */
+ 
+-#if !defined(__linux__)
+ #define MONO_ARCH_NOMAP32BIT 1
+-#endif
+ 
+ #ifdef TARGET_WIN32
+ #define MONO_AMD64_ARG_REG1 AMD64_RCX
+diff --git a/mono/utils/mono-codeman.c b/mono/utils/mono-codeman.c
+index 234aac4b0ca..5eccda92bd0 100644
+--- a/mono/utils/mono-codeman.c
++++ b/mono/utils/mono-codeman.c
+@@ -68,11 +68,7 @@ static const MonoCodeManagerCallbacks *code_manager_callbacks;
+ #define MAX_WASTAGE 32
+ #define MIN_BSIZE 32
+
+-#ifdef __x86_64__
+-#define ARCH_MAP_FLAGS MONO_MMAP_32BIT
+-#else
+ #define ARCH_MAP_FLAGS 0
+-#endif
+
+ #define MONO_PROT_RWX (MONO_MMAP_READ|MONO_MMAP_WRITE|MONO_MMAP_EXEC|MONO_MMAP_JIT)
+
+--
+2.40.1

--- a/recipes-mono/mono/mono-native-6.xx-base.inc
+++ b/recipes-mono/mono/mono-native-6.xx-base.inc
@@ -7,7 +7,7 @@ RPROVIDES:${PN} += "nativesdk-mono"
 PROVIDES += "nativesdk-mono"
 
 do_compile() {
-    make EXTERNAL_MCS="${S}/mcs/class/lib/monolite/basic.exe" EXTERNAL_RUNTIME="${S}/foo/bar/mono"
+    oe_runmake EXTERNAL_MCS="${S}/mcs/class/lib/monolite/basic.exe" EXTERNAL_RUNTIME="${S}/foo/bar/mono"
 }
 
 EDEPENDS_X11 =+ "libgdiplus-native"

--- a/recipes-mono/mono/mono-native_6.12.0.161.bb
+++ b/recipes-mono/mono/mono-native_6.12.0.161.bb
@@ -27,6 +27,7 @@ SRC_URI = "http://download.mono-project.com/sources/mono/mono-${BASEPV}.tar.xz \
            file://0036-Revert-2020-02-Start-a-dedicated-thread-for-MERP-cra.patch \
            file://0037-Allow-nfloat-to-be-in-the-ObjCRuntime-namespace-and-.patch \
            file://0039-aot-Prepend-the-assembly-name-to-the-names-of-gshare.patch \
+           file://disable-mmap-MAP_32BIT-support.patch \
 "
 
 addtask fixup_config after do_patch before do_configure

--- a/recipes-mono/mono/mono_6.12.0.161.bb
+++ b/recipes-mono/mono/mono_6.12.0.161.bb
@@ -28,6 +28,7 @@ SRC_URI = "http://download.mono-project.com/sources/mono/mono-${BASEPV}.tar.xz \
            file://0036-Revert-2020-02-Start-a-dedicated-thread-for-MERP-cra.patch \
            file://0037-Allow-nfloat-to-be-in-the-ObjCRuntime-namespace-and-.patch \
            file://0039-aot-Prepend-the-assembly-name-to-the-names-of-gshare.patch \
+           file://disable-mmap-MAP_32BIT-support.patch \
 "
 
 


### PR DESCRIPTION
@ajlennon The patch from https://github.com/mono/mono/issues/21651#issuecomment-1539830484 fixes the segfault when building mono-native. Tested with kernel 6.3.1 on the Fedora 38 build host.

Fixes #180 
