### PR TITLE
Add msbuild 16.10.1 recipe

### DIFF
--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         dotnet_version: [7.0.202]
-        mono_version: [6.12.0.161]
+        mono_version: [6.12.0.182]
         branch: [langdale]
         arch: [x86-64, arm, arm64]
     env:

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -19,7 +19,7 @@ PREFERRED_VERSION_libgdiplus-native ?= "6.0.5"
 PREFERRED_VERSION_nuget ?= "5.2.0"
 PREFERRED_VERSION_nuget-native ?= "5.2.0"
 
-PREFERRED_VERSION_msbuild ?= "16.6"
-PREFERRED_VERSION_msbuild-native ?= "16.6"
+PREFERRED_VERSION_msbuild ?= "16.10.1"
+PREFERRED_VERSION_msbuild-native ?= "16.10.1"
 
 LAYERSERIES_COMPAT_mono = "kirkstone langdale mickledore"

--- a/recipes-mono/msbuild/msbuild-16.10.1/0001-Copy-hostfxr.patch
+++ b/recipes-mono/msbuild/msbuild-16.10.1/0001-Copy-hostfxr.patch
@@ -1,0 +1,21 @@
+From be8f534947136661bfec11410da7767e92adb1f3 Mon Sep 17 00:00:00 2001
+From: Nicolas Jeker <n.jeker@gmx.net>
+Date: Fri, 22 Jan 2021 10:41:27 +0100
+Subject: [PATCH] Copy hostfxr
+
+---
+ eng/cibuild_bootstrapped_msbuild.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/eng/cibuild_bootstrapped_msbuild.sh b/eng/cibuild_bootstrapped_msbuild.sh
+index 759c75f..cfa3c28 100755
+--- a/eng/cibuild_bootstrapped_msbuild.sh
++++ b/eng/cibuild_bootstrapped_msbuild.sh
+@@ -61,6 +61,7 @@ function DownloadMSBuildForMono {
+     unzip -q "$msbuild_zip" -d "$artifacts_dir"
+     # rename just to make it obvious when reading logs!
+     mv $artifacts_dir/msbuild $mono_msbuild_dir
++    cp %libhostfxr% $artifacts_dir/mono-msbuild/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver/
+     sed -i 's#/sh$#/bash#' $artifacts_dir/mono-msbuild/msbuild
+     chmod +x $artifacts_dir/mono-msbuild/MSBuild.dll
+ 

--- a/recipes-mono/msbuild/msbuild-16.10.1/mono-msbuild-use-bash.patch
+++ b/recipes-mono/msbuild/msbuild-16.10.1/mono-msbuild-use-bash.patch
@@ -1,0 +1,42 @@
+Index: xamarin-pkg-msbuild/gen_build_info.sh
+===================================================================
+--- xamarin-pkg-msbuild.orig/gen_build_info.sh
++++ xamarin-pkg-msbuild/gen_build_info.sh
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ if [ $# -ne 1 ]; then
+ 	echo "Usage: $0 <filename.cs>"
+Index: xamarin-pkg-msbuild/mono/create_bootstrap.sh
+===================================================================
+--- xamarin-pkg-msbuild.orig/mono/create_bootstrap.sh
++++ xamarin-pkg-msbuild/mono/create_bootstrap.sh
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ # This creates a bootstrap from an exising mono installation
+ # This is just to ensure that we have the correct "matched" Roslyn
+Index: xamarin-pkg-msbuild/msbuild-deploy.in
+===================================================================
+--- xamarin-pkg-msbuild.orig/msbuild-deploy.in
++++ xamarin-pkg-msbuild/msbuild-deploy.in
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ ABSOLUTE_PATH=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)/`basename "${BASH_SOURCE[0]}"`
+ MSBUILD_SRC_DIR=`dirname $ABSOLUTE_PATH`
+ mono $MONO_OPTIONS $MSBUILD_SRC_DIR/MSBuild.exe $*
+Index: xamarin-pkg-msbuild/eng/cibuild_bootstrapped_msbuild.sh
+===================================================================
+--- xamarin-pkg-msbuild.orig/eng/cibuild_bootstrapped_msbuild.sh
++++ xamarin-pkg-msbuild/eng/cibuild_bootstrapped_msbuild.sh
+@@ -61,6 +61,7 @@ function DownloadMSBuildForMono {
+     unzip -q "$msbuild_zip" -d "$artifacts_dir"
+     # rename just to make it obvious when reading logs!
+     mv $artifacts_dir/msbuild $mono_msbuild_dir
++    sed -i 's#/sh$#/bash#' $artifacts_dir/mono-msbuild/msbuild
+     chmod +x $artifacts_dir/mono-msbuild/MSBuild.dll
+ 
+     if [[ `uname -s` != 'Darwin' ]]; then

--- a/recipes-mono/msbuild/msbuild_16.10.1.bb
+++ b/recipes-mono/msbuild/msbuild_16.10.1.bb
@@ -1,0 +1,70 @@
+SUMMARY = "The Microsoft Build Engine is a platform for building applications."
+HOMEPAGE = "https://docs.microsoft.com/visualstudio/msbuild/msbuild"
+SECTION = "console/apps"
+LICENSE = "MIT"
+
+DEPENDS = "curl-native ca-certificates-native unzip-native dotnet-native"
+
+RDEPENDS_${PN} = "dotnet"
+
+LIC_FILES_CHKSUM = "file://license;md5=aa2bb45abfacf721bd09860b11b79f5a \
+                    file://ref/LicenseHeader.txt;md5=b06c0743af93aeb14a577bb2bfdada8e"
+
+inherit mono
+
+SRCREV = "8463cdd28537acbca482d2a14804f61ab7838383"
+
+SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git;branch=main;protocol=https \
+           file://mono-msbuild-license-case.patch \
+           file://mono-msbuild-use-bash.patch \
+           file://0001-Don-t-try-to-run-pkill.patch \
+           file://0001-Copy-hostfxr.patch \
+           "
+
+S = "${WORKDIR}/git"
+
+do_configure () {
+    sed "s|%libhostfxr%|${STAGING_DIR_TARGET}${libdir}/libhostfxr.so|g" -i ${S}/eng/cibuild_bootstrapped_msbuild.sh
+
+    sed "s|\$(HOME)\\\.nuget\\\packages|${NUGET_PACKAGES}|g" -i ${S}/mono/build/common.props
+    sed "s|\$(MonoInstallPrefix)\\\lib|${D}${libdir}|g" -i ${S}/mono/build/install.proj
+    sed "s|\$(MonoInstallPrefix)\\\bin|${D}${bindir}|g" -i ${S}/mono/build/install.proj
+    sed "s|\$(MonoInstallPrefix)\\\share|${D}${datadir}|g" -i ${S}/mono/build/install.proj
+
+    sed "s|'\$1'/bin|${bindir}|g" -i ${S}/mono/build/gen_msbuild_wrapper.sh
+    sed "s|\$1/lib|${libdir}|g" -i ${S}/mono/build/gen_msbuild_wrapper.sh
+}
+
+export DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR="${STAGING_DATADIR_NATIVE}/dotnet"
+export CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt"
+
+do_compile[network] = "1"
+
+do_compile () {
+    mkdir -p ${WORKDIR}/build-home-dir
+    export HOME=${WORKDIR}/build-home-dir
+
+    # Sync Mono certificate store with ca-certificates
+    cert-sync --user ${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt
+
+    # Trust extra sites
+    yes | ${STAGING_BINDIR_NATIVE}/certmgr -ssl https://nugetgallery.blob.core.windows.net
+    yes | ${STAGING_BINDIR_NATIVE}/certmgr -ssl https://nuget.org
+    yes | ${STAGING_BINDIR_NATIVE}/certmgr -ssl https://api.nuget.org
+    yes | ${STAGING_BINDIR_NATIVE}/certmgr -ssl https://go.microsoft.com
+
+    ./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests /p:DisableNerdbankVersioning=true
+}
+
+do_install () {
+    export HOME=${WORKDIR}/build-home-dir
+
+    ./stage1/mono-msbuild/msbuild mono/build/install.proj /p:MonoInstallPrefix="${D}" /p:Configuration=Release-MONO /p:IgnoreDiffFailure=true
+}
+
+FILES:${PN} = "\
+    ${bindir} \
+    ${libdir}/mono \
+"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
It fixes the error in our in-house project that is really an inconsistency between the older msbuild 16.6 and the newest Mono.