### PR TITLE
libgdiplus: Use git:// SRC_URI

### DIFF
--- a/recipes-mono/libgdiplus/libgdiplus-common.inc
+++ b/recipes-mono/libgdiplus/libgdiplus-common.inc
@@ -5,7 +5,17 @@ BUGTRACKER = "http://bugzilla.xamarin.com/"
 SECTION = "libs"
 LICENSE = "MIT"
 
-SRC_URI = "https://github.com/mono/libgdiplus/archive/${PV}.tar.gz;downloadfilename=${BPN}-${PV}.tar.gz"
+BRANCH ?= "main"
+
+BRANCH_googletest ?= "v1.8.x"
+SRCREV_googletest = "dea0216d0c6bc5e63cf5f6c8651cd268668032ec"
+
+SRC_URI = " \
+	git://github.com/mono/libgdiplus.git;protocol=https;branch=${BRANCH} \
+	gitsm://github.com/google/googletest.git;protocol=https;name=googletest;branch=${BRANCH_googletest};destsuffix=git/external/googletest \
+"
+
+S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig
 

--- a/recipes-mono/libgdiplus/libgdiplus-native_4.2.bb
+++ b/recipes-mono/libgdiplus/libgdiplus-native_4.2.bb
@@ -5,5 +5,4 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=fe7364dfce9f3689eb6995e7cdd56879"
 
 SRC_URI += "file://libgdiplus-2.10.9-format.patch"
 
-SRC_URI[md5sum] = "925709982aba701c567850617e2206b1"
-SRC_URI[sha256sum] = "98f8a8e58ed22e136c4ac6eaafbc860757f5a97901ecc0ea357e2b6e4cfa2be5"
+SRCREV = "109aeea93fbf8c9da94e9e9a8ed6c6e433c8d554"

--- a/recipes-mono/libgdiplus/libgdiplus-native_6.0.4.bb
+++ b/recipes-mono/libgdiplus/libgdiplus-native_6.0.4.bb
@@ -3,5 +3,5 @@ require libgdiplus-native.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=e0a7dacaa67d7e24a32074fba736dc59"
 
-SRC_URI[md5sum] = "3f94b3d61934eecccaaac5a49501b283"
-SRC_URI[sha256sum] = "9a5e3f98018116f99361520348e9713cd05680c231d689a83d87acfaf237d3a8"
+BRANCH = "release/6.0"
+SRCREV = "c5b9035d14146e054f2636f2e70dd3577bdaa397"

--- a/recipes-mono/libgdiplus/libgdiplus-native_6.0.5.bb
+++ b/recipes-mono/libgdiplus/libgdiplus-native_6.0.5.bb
@@ -3,5 +3,5 @@ require libgdiplus-native.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=e0a7dacaa67d7e24a32074fba736dc59"
 
-SRC_URI[md5sum] = "8079300e708c7ea9b4254d4b2eeba463"
-SRC_URI[sha256sum] = "1fd034f4b636214cc24e94c563cd10b3f3444d9f0660927b60e63fd4131d97fa"
+BRANCH = "release/6.0"
+SRCREV = "110bdc284272258a0d9c95db0de8fcf34b6888b0"

--- a/recipes-mono/libgdiplus/libgdiplus_4.2.bb
+++ b/recipes-mono/libgdiplus/libgdiplus_4.2.bb
@@ -8,5 +8,4 @@ SRC_URI += " \
 		file://libgdiplus-2.10.9-format.patch \
 	"
 
-SRC_URI[md5sum] = "925709982aba701c567850617e2206b1"
-SRC_URI[sha256sum] = "98f8a8e58ed22e136c4ac6eaafbc860757f5a97901ecc0ea357e2b6e4cfa2be5"
+SRCREV = "109aeea93fbf8c9da94e9e9a8ed6c6e433c8d554"

--- a/recipes-mono/libgdiplus/libgdiplus_6.0.2.bb
+++ b/recipes-mono/libgdiplus/libgdiplus_6.0.2.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=e0a7dacaa67d7e24a32074fba736dc59"
 
 SRC_URI += "file://0001-fix-cross-compile.patch"
 
-SRC_URI[md5sum] = "94f9f05004e6054e414d747844e897b0"
-SRC_URI[sha256sum] = "d605bf548affd29bd0418001ffb1bb8c1bf9962c1c37c23744abb0194a099232"
+BRANCH = "release/6.0"
+SRCREV = "35ae5341c2326c44e26058ca90b12303bb9b1da0"

--- a/recipes-mono/libgdiplus/libgdiplus_6.0.4.bb
+++ b/recipes-mono/libgdiplus/libgdiplus_6.0.4.bb
@@ -7,5 +7,5 @@ SRC_URI += " \
 		file://0001-fix-cross-compile.patch \
 		"
 
-SRC_URI[md5sum] = "3f94b3d61934eecccaaac5a49501b283"
-SRC_URI[sha256sum] = "9a5e3f98018116f99361520348e9713cd05680c231d689a83d87acfaf237d3a8"
+BRANCH = "release/6.0"
+SRCREV = "c5b9035d14146e054f2636f2e70dd3577bdaa397"

--- a/recipes-mono/libgdiplus/libgdiplus_6.0.5.bb
+++ b/recipes-mono/libgdiplus/libgdiplus_6.0.5.bb
@@ -7,5 +7,5 @@ SRC_URI += " \
 		file://0001-fix-cross-compile.patch \
 		"
 
-SRC_URI[md5sum] = "8079300e708c7ea9b4254d4b2eeba463"
-SRC_URI[sha256sum] = "1fd034f4b636214cc24e94c563cd10b3f3444d9f0660927b60e63fd4131d97fa"
+BRANCH = "release/6.0"
+SRCREV = "110bdc284272258a0d9c95db0de8fcf34b6888b0"


### PR DESCRIPTION
This fixes the QA warning in Yocto:

WARNING: libgdiplus-native-6.0.5-r0 do_unpack: QA Issue: libgdiplus-native: SRC_URI uses unstable GitHub/GitLab archives, convert recipe to use git protocol [src-uri-bad]
WARNING: libgdiplus-6.0.5-r0 do_unpack: QA Issue: libgdiplus: SRC_URI uses unstable GitHub/GitLab archives, convert recipe to use git protocol [src-uri-bad]