### PR TITLE
Update dotnet-helloworld_1.0.bb

### DIFF
--- a/recipes-mono/dotnet-helloworld/dotnet-helloworld_1.0.bb
+++ b/recipes-mono/dotnet-helloworld/dotnet-helloworld_1.0.bb
@@ -41,6 +41,7 @@ do_install () {
     cp -r --no-preserve=ownership ${B}/${PN} ${D}/opt
 
     if [ "${SRC_ARCH}" = "x64" ]; then
+        install -d ${D}/lib64/
         ln -s ${base_libdir} ${D}/lib64
     fi
 }


### PR DESCRIPTION
solve ERROR: dotnet-helloworld-1.0-r0 do_package: File './lib64/*.a' cannot be packaged into 'dotnet-helloworld-staticdev' because its parent directory structure does not exist. One of its parent directories is a symlink whose target directory is not included in the package.