### PR TITLE
mono: add BBCLASSEXTEND=native to mono-6.xx.inc (#149)

### DIFF
--- a/classes/mono.bbclass
+++ b/classes/mono.bbclass
@@ -1,8 +1,8 @@
 # Class for building C# packages. If your package is all-managed, add
 # PACKAGE_ARCH="all"
 
-DEPENDS:append = " mono-native ca-certificates-native mono"
-RDEPENDS:${PN}:append = " mono"
+DEPENDS += "mono-native ca-certificates-native mono"
+RDEPENDS:${PN} += "mono"
 
 FILES:${PN}:append = " \
   ${libdir}/mono/*/*.exe \

--- a/recipes-mono/mono/mono-6.12.0.161.inc
+++ b/recipes-mono/mono/mono-6.12.0.161.inc
@@ -3,7 +3,7 @@ SRC_URI[sha256sum] = "29c277660fc5e7513107aee1cbf8c5057c9370a4cdfeda2fc781be6986
 
 S = "${WORKDIR}/mono-${BASEPV}"
 
-DEPENDS += " cmake-native"
+DEPENDS += "cmake-native"
 
 do_configure:prepend () {
 	sed -i 's/${BASEPV}/${PV}/g' configure.ac

--- a/recipes-mono/mono/mono-6.xx.inc
+++ b/recipes-mono/mono/mono-6.xx.inc
@@ -4,7 +4,7 @@ HOMEPAGE = "http://mono-project.com"
 BUGTRACKER = "http://bugzilla.xamarin.com/"
 SECTION = "devel"
 
-DEPENDS = "zlib libatomic-ops"
+DEPENDS += "zlib libatomic-ops"
 
 SRC_URI = "http://download.mono-project.com/sources/mono/mono-${PV}.tar.xz \
            file://dllmap-config.in.diff \

--- a/recipes-mono/mono/mono-base.inc
+++ b/recipes-mono/mono/mono-base.inc
@@ -1,4 +1,4 @@
-DEPENDS = "mono-native"
+DEPENDS += "mono-native"
 
 EXTRA_OECONF += " --disable-mcs-build mono_cv_clang=no "
 

--- a/recipes-mono/mono/mono-native-6.xx-base.inc
+++ b/recipes-mono/mono/mono-native-6.xx-base.inc
@@ -23,3 +23,13 @@ do_populate_sysroot[postfuncs] += " mono_copy_libdir_mono "
 do_install:append() {
     sed "s|\$mono_libdir|${libdir}|g" -i ${D}${sysconfdir}/mono/config
 }
+
+# Adding BBCLASSEXTEND = "native" here allows recipes including this
+# file to have their dependenvies adjusted automatically. This is
+# required for example when compiling msbuild-native, which depends on
+# mono-native (but must not depend on mono).
+#
+# Ideally, we would only declare BBCLASSEXTEND = "native" in a main
+# recipe for mono and let bitbake generate a -native version of the
+# recipe automatically.
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
* mono-base: append dependencies instead of using the hard assignment op

* Remove extra space

Not needed when using the += operator.



* Fix build on aarch64 builds

When building for aarch64 targets, I get build failures like:

ERROR: msbuild-native-16.6-r0 do_prepare_recipe_sysroot: Manifest /workdir/build/tmp/sstate-control/manifest-x86_64_x86_64-nativesdk-mono.populate_sysroot not found in imx8mn_ddr4_evk cortexa53 armv8a-crc armv8a aarch64 allarch x86_64_x86_64-nativesdk (variant '')?

The problem comes from the fact that some include files (i.e.: mono-6.xx.inc) are used in both the mono and mono-native variants. This seems to confuse the native class in some way. Ideally we would have a single mono recipe declaring BBCLASSEXTEND = "native" and we'd let bitbake generate the recipe variant.

See: https://docs.yoctoproject.org/ref-manual/variables.html?highlight=bbclassextend#term-BBCLASSEXTEND



* Fix build error of CI-Build:

Error:

 Problem 1: conflicting requests
  - nothing provides mono-gac needed by mono-6.12.0.161-r0.core2_64
  - nothing provides mono-libs-4.5 needed by mono-6.12.0.161-r0.core2_64

 Problem 2: package msbuild-16.6-r0.core2_64 requires mono, but none of the providers can be installed
  - conflicting requests
  - nothing provides mono-gac needed by mono-6.12.0.161-r0.core2_64
  - nothing provides mono-libs-4.5 needed by mono-6.12.0.161-r0.core2_64

 Problem 3: package mono-helloworld-1.2-r0.core2_64 requires mono, but none of the providers can be installed
  - conflicting requests
  - nothing provides mono-gac needed by mono-6.12.0.161-r0.core2_64
  - nothing provides mono-libs-4.5 needed by mono-6.12.0.161-r0.core2_64 (try to add '--skip-broken' to skip uninstallable packages)