### PR TITLE
CI_github: Use Node 20 instead of Node 16

### DIFF
--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -29,7 +29,7 @@ jobs:
       BRANCH: ${{ matrix.branch }}
     steps:
     - name: Checkout meta-mono
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         clean: false
         path: ${{ matrix.branch }}/meta-mono
@@ -90,7 +90,7 @@ jobs:
         export TERM=linux
         bitbake test-image-mono -c testimage
     - name: Store artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-image-mono-${{ github.sha }}
         path: ./${{ matrix.branch }}/build/tmp/deploy/images/qemu${{ matrix.arch }}/


### PR DESCRIPTION
Fix warning from GitHub CI build:

```
build-and-test (6.0.419, 6.12.0.182, nanbield, arm)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```