### PR TITLE
ci: optimize CI build

### DIFF
--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -90,7 +90,7 @@ jobs:
         export TERM=linux
         bitbake test-image-mono -c testimage
     - name: Store artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: test-image-mono-${{ github.sha }}
+        name: test-image-mono-${{ matrix.branch }}-${{ matrix.mono_version }}-${{ matrix.dotnet_version }}-${{ github.sha }}-${{ matrix.arch }}
         path: ./${{ matrix.branch }}/build/tmp/deploy/images/qemu${{ matrix.arch }}/

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Cleaning
       run: |
         . ./${BRANCH}/poky/oe-init-build-env ${BRANCH}/build
-        bitbake -c cleanall test-image-mono mono mono-native mono-helloworld msbuild msbuild-native dotnet dotnet-native python3-clr-loader python3-clr-loader-native dotnet-helloworld python3-pythonnet
+        bitbake -c cleanall test-image-mono dotnet dotnet-native
     - name: Building
       run: |
         . ./${BRANCH}/poky/oe-init-build-env ${BRANCH}/build

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -29,7 +29,7 @@ jobs:
       BRANCH: ${{ matrix.branch }}
     steps:
     - name: Checkout meta-mono
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         clean: false
         path: ${{ matrix.branch }}/meta-mono
@@ -90,7 +90,7 @@ jobs:
         export TERM=linux
         bitbake test-image-mono -c testimage
     - name: Store artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-image-mono-${{ github.sha }}
         path: ./${{ matrix.branch }}/build/tmp/deploy/images/qemu${{ matrix.arch }}/

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -90,7 +90,7 @@ jobs:
         export TERM=linux
         bitbake test-image-mono -c testimage
     - name: Store artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: test-image-mono-${{ github.sha }}
         path: ./${{ matrix.branch }}/build/tmp/deploy/images/qemu${{ matrix.arch }}/

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -22,4 +22,11 @@ PREFERRED_VERSION_nuget-native ?= "5.2.0"
 PREFERRED_VERSION_msbuild ?= "16.10.1"
 PREFERRED_VERSION_msbuild-native ?= "16.10.1"
 
+# Suppress TMPDIR [buildpaths] warning
+INSANE_SKIP:mono += "buildpaths"
+INSANE_SKIP:msbuild += "buildpaths"
+INSANE_SKIP:python3-clr-loader += "buildpaths"
+INSANE_SKIP:python3-pythonnet += "buildpaths"
+INSANE_SKIP:dotnet-helloworld += "buildpaths"
+
 LAYERSERIES_COMPAT_mono = "kirkstone langdale mickledore nanbield"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,10 +23,14 @@ PREFERRED_VERSION_msbuild ?= "16.10.1"
 PREFERRED_VERSION_msbuild-native ?= "16.10.1"
 
 # Suppress TMPDIR [buildpaths] warning
-INSANE_SKIP:mono += "buildpaths"
+INSANE_SKIP:mono-dbg += "buildpaths"
+INSANE_SKIP:mono-gac += "buildpaths"
+INSANE_SKIP:mono-configuration-crypto += "buildpaths"
+INSANE_SKIP:mono-xbuild += "buildpaths"
+INSANE_SKIP:mono-libs-4.5 += "buildpaths"
 INSANE_SKIP:msbuild += "buildpaths"
+INSANE_SKIP:msbuild-dev += "buildpaths"
 INSANE_SKIP:python3-clr-loader += "buildpaths"
 INSANE_SKIP:python3-pythonnet += "buildpaths"
-INSANE_SKIP:dotnet-helloworld += "buildpaths"
 
 LAYERSERIES_COMPAT_mono = "kirkstone langdale mickledore nanbield"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -24,9 +24,6 @@ PREFERRED_VERSION_msbuild-native ?= "16.10.1"
 
 # Suppress TMPDIR [buildpaths] warning
 INSANE_SKIP:mono-dbg += "buildpaths"
-INSANE_SKIP:mono-gac += "buildpaths"
-INSANE_SKIP:mono-configuration-crypto += "buildpaths"
-INSANE_SKIP:mono-xbuild += "buildpaths"
 INSANE_SKIP:mono-libs-4.5 += "buildpaths"
 INSANE_SKIP:msbuild += "buildpaths"
 INSANE_SKIP:msbuild-dev += "buildpaths"

--- a/recipes-mono/mono-helloworld/mono-helloworld.inc
+++ b/recipes-mono/mono-helloworld/mono-helloworld.inc
@@ -4,7 +4,7 @@ AUTHOR = "Alex J Lennon <ajlennon@dynamicdevices.co.uk>"
 HOMEPAGE = "http://www.dynamicdevices.co.uk"
 SECTION = "mono/applications"
 PRIORITY = "optional"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=783b7e40cdfb4a1344d15b1f7081af66"
 
 SRC_URI = "https://github.com/DynamicDevices/mono-helloworld/releases/download/v${PV}/mono-helloworld-${PV}.tar.gz"


### PR DESCRIPTION
- Use Node 20 instead of Node 16
- Use `bitbake -c cleanall test-image-mono dotnet dotnet-native` only for reduce rebuild time
- Suppress TMPDIR warnings