### PR TITLE
recipes: Switch away from S = WORKDIR and transition to UNPACKDIR fro…

### DIFF
--- a/classes/mono.bbclass
+++ b/classes/mono.bbclass
@@ -35,8 +35,8 @@ export MONO_CFG_DIR="${STAGING_ETCDIR_NATIVE}"
 
 # NuGet uses $HOME/.nuget/packages to store packages by default
 # but we should not use anything outside the build root of packages.
-export NUGET_PACKAGES="${WORKDIR}/mono-nuget-packages"
-export NUGET_HTTP_CACHE_PATH="${WORKDIR}/mono-nuget-http-cache"
+export NUGET_PACKAGES="${UNPACKDIR}/mono-nuget-packages"
+export NUGET_HTTP_CACHE_PATH="${UNPACKDIR}/mono-nuget-http-cache"
 
 do_configure:prepend() {
 	mkdir -p ${NUGET_PACKAGES} ${NUGET_HTTP_CACHE_PATH}

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -30,4 +30,4 @@ INSANE_SKIP:msbuild-dev += "buildpaths"
 INSANE_SKIP:python3-clr-loader += "buildpaths"
 INSANE_SKIP:python3-pythonnet += "buildpaths"
 
-LAYERSERIES_COMPAT_mono = "kirkstone langdale mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_mono = "styhead"

--- a/recipes-browser/cefglue/cefglue.inc
+++ b/recipes-browser/cefglue/cefglue.inc
@@ -16,7 +16,7 @@ SRC_URI = "https://bitbucket.org/xilium/xilium.cefglue/get/v${PV}.tar.bz2 \
 inherit autotools-brokensep
 
 do_configure() {
-  cp -f ${WORKDIR}/build_4.0_client_profile.sh ${S}
+  cp -f ${UNPACKDIR}/build_4.0_client_profile.sh ${S}
 }
 
 do_compile() {

--- a/recipes-mono/msbuild/msbuild_16.10.1.bb
+++ b/recipes-mono/msbuild/msbuild_16.10.1.bb
@@ -41,8 +41,8 @@ export CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt"
 do_compile[network] = "1"
 
 do_compile () {
-    mkdir -p ${WORKDIR}/build-home-dir
-    export HOME=${WORKDIR}/build-home-dir
+    mkdir -p ${UNPACKDIR}/build-home-dir
+    export HOME=${UNPACKDIR}/build-home-dir
 
     # Sync Mono certificate store with ca-certificates
     cert-sync --user ${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt
@@ -57,7 +57,7 @@ do_compile () {
 }
 
 do_install () {
-    export HOME=${WORKDIR}/build-home-dir
+    export HOME=${UNPACKDIR}/build-home-dir
 
     ./stage1/mono-msbuild/msbuild mono/build/install.proj /p:MonoInstallPrefix="${D}" /p:Configuration=Release-MONO /p:IgnoreDiffFailure=true
 }

--- a/recipes-mono/nuget/nuget.inc
+++ b/recipes-mono/nuget/nuget.inc
@@ -20,15 +20,16 @@ SRC_URI = " \
 SRC_URI[lic.md5sum] = "3b83ef96387f14655fc854ddc3c6bd57"
 SRC_URI[lic.sha256sum] = "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 do_install () {
 	install -d -m0755 ${D}${bindir}
-	install -m0755 ${WORKDIR}/nuget.sh.in ${D}${bindir}/nuget
+	install -m0755 ${UNPACKDIR}/nuget.sh.in ${D}${bindir}/nuget
 	sed -i -e 's:@bindir@:${bindir}:g' -e 's:@libdir@:${libdir}:g' ${D}${bindir}/nuget
 
 	install -d -m0755 ${D}${libdir}/mono/nuget
-	install -m0755 ${WORKDIR}/NuGet-v${PV}.exe ${D}${libdir}/mono/nuget/NuGet.exe
+	install -m0755 ${UNPACKDIR}/NuGet-v${PV}.exe ${D}${libdir}/mono/nuget/NuGet.exe
 }
 
 FILES:${PN} += "${libdir}/mono/nuget"
@@ -37,7 +38,7 @@ SYSROOT_PREPROCESS_FUNCS += "nuget_sysroot_preprocess"
 
 nuget_sysroot_preprocess () {
 	install -d -m0755 ${SYSROOT_DESTDIR}${bindir_crossscripts}/
-	install -m0755 ${WORKDIR}/nuget.sh.in ${SYSROOT_DESTDIR}${bindir_crossscripts}/nuget
+	install -m0755 ${UNPACKDIR}/nuget.sh.in ${SYSROOT_DESTDIR}${bindir_crossscripts}/nuget
 	sed -i -e 's:@bindir@:${STAGING_BINDIR_NATIVE}:g' -e 's:@libdir@:${STAGING_LIBDIR}:g' ${SYSROOT_DESTDIR}${bindir_crossscripts}/nuget
 }
 

--- a/recipes-python/python3-clr-loader/python3-clr-loader.bb
+++ b/recipes-python/python3-clr-loader/python3-clr-loader.bb
@@ -28,9 +28,9 @@ RDEPENDS:${PN} += " \
 
 # NuGet uses $HOME/.nuget/packages to store packages by default
 # but we should not use anything outside the build root of packages.
-# Use a separated folder for nuget downloads and cache in WORKDIR.
-export NUGET_PACKAGES="${WORKDIR}/nuget-packages"
-export NUGET_HTTP_CACHE_PATH="${WORKDIR}/nuget-http-cache"
+# Use a separated folder for nuget downloads and cache in UNPACKDIR.
+export NUGET_PACKAGES="${UNPACKDIR}/nuget-packages"
+export NUGET_HTTP_CACHE_PATH="${UNPACKDIR}/nuget-http-cache"
 
 # Workaround for dotnet restore issue, define custom proxy in a .bbappend
 # and/or in layer.conf or local.conf if dotnet restore was failed.

--- a/recipes-python/python3-pythonnet/python3-pythonnet.bb
+++ b/recipes-python/python3-pythonnet/python3-pythonnet.bb
@@ -37,9 +37,9 @@ RDEPENDS:${PN} += " \
 
 # NuGet uses $HOME/.nuget/packages to store packages by default
 # but we should not use anything outside the build root of packages.
-# Use a separated folder for nuget downloads and cache in WORKDIR.
-export NUGET_PACKAGES="${WORKDIR}/nuget-packages"
-export NUGET_HTTP_CACHE_PATH="${WORKDIR}/nuget-http-cache"
+# Use a separated folder for nuget downloads and cache in UNPACKDIR.
+export NUGET_PACKAGES="${UNPACKDIR}/nuget-packages"
+export NUGET_HTTP_CACHE_PATH="${UNPACKDIR}/nuget-http-cache"
 
 # Workaround for dotnet restore issue, define custom proxy in a .bbappend
 # and/or in layer.conf or local.conf if dotnet restore was failed.
@@ -59,8 +59,8 @@ do_configure:prepend() {
 do_compile[network] = "1"
 
 do_install:prepend() {
-    printf "${PYTHONNET_ENV}" > ${WORKDIR}/dotnet-env.sh
+    printf "${PYTHONNET_ENV}" > ${UNPACKDIR}/dotnet-env.sh
 
     install -d ${D}${sysconfdir}/profile.d
-    install -m 644 ${WORKDIR}/dotnet-env.sh    ${D}${sysconfdir}/profile.d
+    install -m 644 ${UNPACKDIR}/dotnet-env.sh    ${D}${sysconfdir}/profile.d
 }


### PR DESCRIPTION
…m WORKDIR.

* Using S = ${WORKDIR} is no longer supported.

* UNPACKDIR is new contruct for do_unpack things in latest master we should be using that instead of WORKDIR for referencing those files.

* We don't know yet what changes will be needed to stay compatible with final styhead, but we already know that the last changes for UNPACKDIR aren't compatible with scarthgap, nanbield or others.

https://lists.openembedded.org/g/openembedded-architecture/message/2007
https://docs.yoctoproject.org/next/migration-guides/migration-5.1.html#workdir-changes