### PR TITLE
Styhead support

### DIFF
--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -64,6 +64,7 @@ jobs:
 
         echo "BBLAYERS += '$GITHUB_WORKSPACE/${BRANCH}/meta-mono'" >> conf/bblayers.conf
         echo "BBLAYERS += '$GITHUB_WORKSPACE/${BRANCH}/meta-openembedded/meta-oe'" >> conf/bblayers.conf
+        echo "BBLAYERS += '$GITHUB_WORKSPACE/${BRANCH}/meta-openembedded/meta-python'" >> conf/bblayers.conf
 
         echo "MACHINE=\"qemu${ARCH}\"" >> conf/local.conf
         echo "DL_DIR=\"$GITHUB_WORKSPACE/downloads\"" >> conf/local.conf

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - master-next
-      - scarthgap
+      - styhead
   pull_request:
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
       matrix:
         dotnet_version: [8.0.303, 6.0.424]
         mono_version: [6.12.0.182]
-        branch: [scarthgap]
+        branch: [styhead]
         arch: [x86-64, arm, arm64]
     env:
       name: build-and-test

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -77,6 +77,9 @@ jobs:
 
         echo "INHERIT += \" rm_work \"" >> conf/local.conf
         sed -i 's/#IMAGE_CLASSES += "testimage testsdk"/IMAGE_CLASSES += "testimage "/' conf/local.conf
+
+        echo "BB_NUMBER_THREADS ?= \"\${@oe.utils.cpu_count()}\"" >> conf/local.conf
+        echo "PARALLEL_MAKE ?= \"-j \${@oe.utils.cpu_count()} -l \${@oe.utils.cpu_count()*2}\"" >> conf/local.conf
     - name: Cleaning
       run: |
         . ./${BRANCH}/poky/oe-init-build-env ${BRANCH}/build

--- a/classes/mono.bbclass
+++ b/classes/mono.bbclass
@@ -35,8 +35,8 @@ export MONO_CFG_DIR="${STAGING_ETCDIR_NATIVE}"
 
 # NuGet uses $HOME/.nuget/packages to store packages by default
 # but we should not use anything outside the build root of packages.
-export NUGET_PACKAGES="${WORKDIR}/mono-nuget-packages"
-export NUGET_HTTP_CACHE_PATH="${WORKDIR}/mono-nuget-http-cache"
+export NUGET_PACKAGES="${UNPACKDIR}/mono-nuget-packages"
+export NUGET_HTTP_CACHE_PATH="${UNPACKDIR}/mono-nuget-http-cache"
 
 do_configure:prepend() {
 	mkdir -p ${NUGET_PACKAGES} ${NUGET_HTTP_CACHE_PATH}

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -30,4 +30,4 @@ INSANE_SKIP:msbuild-dev += "buildpaths"
 INSANE_SKIP:python3-clr-loader += "buildpaths"
 INSANE_SKIP:python3-pythonnet += "buildpaths"
 
-LAYERSERIES_COMPAT_mono = "kirkstone langdale mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_mono = "styhead"

--- a/recipes-browser/cefglue/cefglue.inc
+++ b/recipes-browser/cefglue/cefglue.inc
@@ -16,7 +16,7 @@ SRC_URI = "https://bitbucket.org/xilium/xilium.cefglue/get/v${PV}.tar.bz2 \
 inherit autotools-brokensep
 
 do_configure() {
-  cp -f ${WORKDIR}/build_4.0_client_profile.sh ${S}
+  cp -f ${UNPACKDIR}/build_4.0_client_profile.sh ${S}
 }
 
 do_compile() {

--- a/recipes-browser/cefglue/cefglue_3.2171.2039.bb
+++ b/recipes-browser/cefglue/cefglue_3.2171.2039.bb
@@ -4,4 +4,4 @@ SRC_URI += "file://0002_correct-cef3.2171.2039-hashes.patch"
 
 SRC_URI[sha256sum] = "6507643b52b400ac07a23188b479d008ce2b52d42c4c0d8ebaf1bed2cefd2fc0"
 
-S = "${WORKDIR}/xilium-xilium.cefglue-4caf9b2bb5b5"
+S = "${UNPACKDIR}/xilium-xilium.cefglue-4caf9b2bb5b5"

--- a/recipes-mono/dbus-sharp-glib/dbus-sharp-glib.inc
+++ b/recipes-mono/dbus-sharp-glib/dbus-sharp-glib.inc
@@ -17,7 +17,7 @@ SDIRVER = "${@dbus_sharp_glib_download_version(d)}"
 
 SRC_URI = "https://github.com/mono/dbus-sharp-glib/archive/v${SDIRVER}.tar.gz"
 
-S = "${WORKDIR}/${PN}-${SDIRVER}"
+S = "${UNPACKDIR}/${PN}-${SDIRVER}"
 
 FILESPATH =. "${FILE_DIRNAME}/${PN}-${PV}:"
 

--- a/recipes-mono/dotnet-helloworld/dotnet-helloworld_1.0.bb
+++ b/recipes-mono/dotnet-helloworld/dotnet-helloworld_1.0.bb
@@ -25,7 +25,7 @@ INSANE_SKIP:${PN} += "\
     buildpaths \
 "
 
-S = "${WORKDIR}/src"
+S = "${UNPACKDIR}/src"
 
 do_compile[network] = "1"
 

--- a/recipes-mono/gtk-sharp/gtk-sharp/0001-fix-range-namespace-ambiguity.patch
+++ b/recipes-mono/gtk-sharp/gtk-sharp/0001-fix-range-namespace-ambiguity.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
 diff -ur gtk-sharp-2.12.45.org/sample/test/TestRange.cs gtk-sharp-2.12.45/sample/test/TestRange.cs
 --- gtk-sharp-2.12.45.org/sample/test/TestRange.cs	2016-09-21 11:49:20.000000000 +0000
 +++ gtk-sharp-2.12.45/sample/test/TestRange.cs	2020-02-04 16:55:49.527862899 +0000

--- a/recipes-mono/gtk-sharp/gtk-sharp/gtk-sharp2-2.12.12-gtkrange.patch
+++ b/recipes-mono/gtk-sharp/gtk-sharp/gtk-sharp2-2.12.12-gtkrange.patch
@@ -1,0 +1,32 @@
+Upstream-Status: Submitted [https://github.com/mono/gtk-sharp/pull/299]
+
+diff --git a/sample/test/TestRange.cs b/sample/test/TestRange.cs
+index 82fb811..29a8ee7 100644
+--- a/sample/test/TestRange.cs
++++ b/sample/test/TestRange.cs
+@@ -32,14 +32,14 @@ namespace WidgetViewer {
+ 
+ 			HScale hscale = new HScale (adjustment);
+ 			hscale.SetSizeRequest (150, -1);
+-			((Range) hscale).UpdatePolicy = UpdateType.Delayed;
++			((Gtk.Range) hscale).UpdatePolicy = UpdateType.Delayed;
+ 
+ 			hscale.Digits = 1;
+ 			hscale.DrawValue = true;
+ 			box2.PackStart (hscale, true, true, 0);
+ 
+ 			HScrollbar hscrollbar = new HScrollbar (adjustment);
+-			((Range) hscrollbar).UpdatePolicy = UpdateType.Continuous;
++			((Gtk.Range) hscrollbar).UpdatePolicy = UpdateType.Continuous;
+ 			box2.PackStart (hscrollbar, true, true, 0);
+ 
+ 			hscale = new HScale (adjustment);
+@@ -59,7 +59,7 @@ namespace WidgetViewer {
+ 			vscale.SetSizeRequest (-1, 200);
+ 			vscale.Digits = 2;
+ 			vscale.DrawValue = true;
+-			((Range) vscale).Inverted = true;
++			((Gtk.Range) vscale).Inverted = true;
+ 			hbox.PackStart (vscale, true, true, 0);
+ 
+ 			vscale = new VScale (adjustment);

--- a/recipes-mono/gtk-sharp/gtk-sharp/gtk-sharp2-c99.patch
+++ b/recipes-mono/gtk-sharp/gtk-sharp/gtk-sharp2-c99.patch
@@ -1,0 +1,35 @@
+Avoid an int-conversion error by adding an explicit cast.
+
+Upstream ported this code to C# in:
+
+commit d7095d495c5188856b2c259ce4871f2c64ed0861
+Author: Christian Hoff <choff@mono-cvs.ximian.com>
+Date:   Tue Mar 17 18:40:35 2009 +0000
+
+    2009-03-17  Christian Hoff  <christian_hoff@gmx.net>
+    
+            * gdk/Property.custom: add new overloads to the Get method
+            for the most common property types
+            * gdk/Global.custom: Use the new overloads of Property.Get instead o
+f glue
+    
+    svn path=/trunk/gtk-sharp/; revision=129618
+
+Signed-off-by: Zoltán Böszörményi <zboszor@gmail.com>
+Upstream-Status: Inactive-Upstream [lastrelease: 2022-11-14]
+
+diff --git a/gdk/glue/windowmanager.c b/gdk/glue/windowmanager.c
+index 484d713b7e2c9037..0ff11f97d26daa8b 100644
+--- a/gdk/glue/windowmanager.c
++++ b/gdk/glue/windowmanager.c
+@@ -110,8 +110,8 @@
+ 	list = g_malloc (*count * sizeof (gpointer));
+ 	/* Put all of the windows into a GList to return */
+ 	for (i = 0; i < *count; i ++) {
+-		list [i] = data [i];
+-		g_message ("WinID: %d", list [i]);
++		list [i] = GINT_TO_POINTER(data [i]);
++		g_message ("WinID: %d", GPOINTER_TO_INT(list [i]));
+ 	}
+ 
+ 	g_free (data);

--- a/recipes-mono/gtk-sharp/gtk-sharp3/0001-fixup-gmcs-to-mcs.patch
+++ b/recipes-mono/gtk-sharp/gtk-sharp3/0001-fixup-gmcs-to-mcs.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
 diff -ur gtk-sharp-2.99.3.org/configure.ac gtk-sharp-2.99.3/configure.ac
 --- gtk-sharp-2.99.3.org/configure.ac	2014-06-06 14:03:34.000000000 +0100
 +++ gtk-sharp-2.99.3/configure.ac	2015-09-28 11:27:29.157332268 +0100

--- a/recipes-mono/gtk-sharp/gtk-sharp3_2.99.3.bb
+++ b/recipes-mono/gtk-sharp/gtk-sharp3_2.99.3.bb
@@ -19,7 +19,7 @@ SRC_URI = "https://download.gnome.org/sources/gtk-sharp/${SDIRVERN}/gtk-sharp-${
 
 SRC_URI[sha256sum] = "6440f571416267ae0cb5698071d087b31e3084693fa2c829b1db37ca7ea2c3a2"
 
-S = "${WORKDIR}/gtk-sharp-${PV}"
+S = "${UNPACKDIR}/gtk-sharp-${PV}"
 
 do_configure:prepend() {
   export PROFILER_CFLAGS="-D_REENTRANT -I${STAGING_DIR_TARGET}/usr/include/glib-2.0 -I${STAGING_DIR_TARGET}/usr/lib/glib-2.0 -I${STAGING_DIR_TARGET}/usr/lib/glib-2.0/include -I${STAGING_DIR_TARGET}/usr/include/mono-2.0"

--- a/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
+++ b/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
@@ -11,7 +11,7 @@ SRCREV = "9a72bb67fff7e4845b7bb430a608282668c3e4da"
 SRC_URI = "git://github.com/mono/gtk-sharp.git;protocol=https;branch=master \
            file://0001-fixup-gmcs-to-mcs.patch"
 
-S = "${WORKDIR}/git"
+S = "${UNPACKDIR}/git"
 
 do_configure:prepend() {
   export PROFILER_CFLAGS="-D_REENTRANT -I${STAGING_DIR_TARGET}/usr/include/glib-2.0 -I${STAGING_DIR_TARGET}/usr/lib/glib-2.0 -I${STAGING_DIR_TARGET}/usr/lib/glib-2.0/include -I${STAGING_DIR_TARGET}/usr/include/mono-2.0"

--- a/recipes-mono/gtk-sharp/gtk-sharp_2.12.45.bb
+++ b/recipes-mono/gtk-sharp/gtk-sharp_2.12.45.bb
@@ -6,7 +6,10 @@ DEPENDS += " gtk+ atk pango cairo glib-2.0"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=7fbc338309ac38fefcd64b04bb903e34"
 
-SRC_URI += "file://0001-fix-range-namespace-ambiguity.patch \
+SRC_URI += " \
+	file://0001-fix-range-namespace-ambiguity.patch \
+	file://gtk-sharp2-c99.patch \
+	file://gtk-sharp2-2.12.12-gtkrange.patch \
 "
 
 SRC_URI[sha256sum] = "02680578e4535441064aac21d33315daa009d742cab8098ac8b2749d86fffb6a"

--- a/recipes-mono/libgdiplus/libgdiplus-6.0.5/0001-configure-Fix-build-with-Gentoo-pango.patch
+++ b/recipes-mono/libgdiplus/libgdiplus-6.0.5/0001-configure-Fix-build-with-Gentoo-pango.patch
@@ -4,6 +4,7 @@ Date: Sat, 18 Apr 2020 11:00:39 +0200
 Subject: [PATCH] configure: Fix build with Gentoo pango
 
 Signed-off-by: Kai Krakow <kai@kaishome.de>
+Upstream-Status: Inappropriate [Yocto specific]
 ---
  configure.ac | 6 +++---
  2 files changed, 6 insertions(+), 6 deletions(-)

--- a/recipes-mono/libgdiplus/libgdiplus-6.0.5/0001-fix-cross-compile.patch
+++ b/recipes-mono/libgdiplus/libgdiplus-6.0.5/0001-fix-cross-compile.patch
@@ -1,3 +1,4 @@
+Upstream-Status: Inappropriate [Yocto specific]
 Index: libgdiplus-6.0.2/configure.ac
 ===================================================================
 --- libgdiplus-6.0.2.orig/configure.ac

--- a/recipes-mono/libgdiplus/libgdiplus-common.inc
+++ b/recipes-mono/libgdiplus/libgdiplus-common.inc
@@ -11,7 +11,7 @@ SRC_URI = " \
 	gitsm://github.com/mono/libgdiplus.git;protocol=https;branch=${BRANCH} \
 "
 
-S = "${WORKDIR}/git"
+S = "${UNPACKDIR}/git"
 
 inherit autotools pkgconfig
 

--- a/recipes-mono/mono-addins/mono-addins-xbuild.inc
+++ b/recipes-mono/mono-addins/mono-addins-xbuild.inc
@@ -13,7 +13,7 @@ SRCBRANCH = "master"
 
 SRC_URI = "git://github.com/mono/mono-addins.git;protocol=https;branch=${SRCBRANCH}"
 
-S = "${WORKDIR}/git"
+S = "${UNPACKDIR}/git"
 
 do_configure() {
 }

--- a/recipes-mono/mono-addins/mono-addins.inc
+++ b/recipes-mono/mono-addins/mono-addins.inc
@@ -14,7 +14,7 @@ SRCBRANCH = "master"
 SRC_URI = "git://github.com/mono/mono-addins.git;protocol=https;branch=${SRCBRANCH} \
 	   file://0001-configure-mcs.patch"
 
-S = "${WORKDIR}/git"
+S = "${UNPACKDIR}/git"
 
 inherit autotools-brokensep pkgconfig
 inherit mono

--- a/recipes-mono/mono-helloworld/mono-helloworld-xbuild_1.2.bb
+++ b/recipes-mono/mono-helloworld/mono-helloworld-xbuild_1.2.bb
@@ -4,7 +4,7 @@ SRC_URI[sha256sum] = "365360d674bd63ab7ca1762e64e3d5d6c6d4841edf6e59f67ff8b40faf
 
 REALPN = "mono-helloworld"
 
-S = "${WORKDIR}/${REALPN}-${PV}"
+S = "${UNPACKDIR}/${REALPN}-${PV}"
 
 CONFIGURATION = "Debug"
 

--- a/recipes-mono/mono-helloworld/mono-helloworld_git.bb.disabled
+++ b/recipes-mono/mono-helloworld/mono-helloworld_git.bb.disabled
@@ -2,4 +2,4 @@ require mono-helloworld.inc
 
 SRCREV = "${AUTOREV}"
 SRC_URI =  "git://github.com/DynamicDevices/mono-helloworld.git" 
-S = "${WORKDIR}/git"
+S = "${UNPACKDIR}/git"

--- a/recipes-mono/mono-upnp/mono-upnp.inc
+++ b/recipes-mono/mono-upnp/mono-upnp.inc
@@ -16,7 +16,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}-${PV}:"
 SRC_URI = "git://github.com/mono/mono-upnp.git;protocol=https;branch=${SRCBRANCH} \
 "
 
-S = "${WORKDIR}/git"
+S = "${UNPACKDIR}/git"
 
 inherit autotools-brokensep pkgconfig
 

--- a/recipes-mono/mono-xsp/mono-xsp-3.x.inc
+++ b/recipes-mono/mono-xsp/mono-xsp-3.x.inc
@@ -19,7 +19,7 @@ do_configure () {
     set -e
 }
 
-S = "${WORKDIR}/xsp-${PV}"
+S = "${UNPACKDIR}/xsp-${PV}"
 
 PACKAGES += "${PN}-test \
 	${PN}-unittest \

--- a/recipes-mono/mono-xsp/mono-xsp.inc
+++ b/recipes-mono/mono-xsp/mono-xsp.inc
@@ -9,7 +9,7 @@ inherit autotools-brokensep
 
 SRC_URI = "http://download.mono-project.com/sources/xsp/xsp-${PV}.tar.bz2"
 
-S = "${WORKDIR}/xsp-${PV}"
+S = "${UNPACKDIR}/xsp-${PV}"
 
 PACKAGES += "${PN}-test \
 	${PN}-unittest \

--- a/recipes-mono/mono-xsp/mono-xsp_git.bb
+++ b/recipes-mono/mono-xsp/mono-xsp_git.bb
@@ -4,4 +4,4 @@ SRCREV= "e272a2c006211b6b03be2ef5bbb9e3f8fefd0768"
 SRC_URI = "git://github.com/mono/xsp.git;branch=main;protocol=https \
 	  "
 
-S = "${WORKDIR}/git"
+S = "${UNPACKDIR}/git"

--- a/recipes-mono/mono/mono-4.xx.inc
+++ b/recipes-mono/mono/mono-4.xx.inc
@@ -29,7 +29,7 @@ def mono_workspace_version (d):
     else:
         return 0
 
-S = "${WORKDIR}/mono-${@mono_workspace_version(d)}"
+S = "${UNPACKDIR}/mono-${@mono_workspace_version(d)}"
 
 FILESPATH =. "${FILE_DIRNAME}/mono-4.xx:"
 FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"

--- a/recipes-mono/mono/mono-5.0.1.1.inc
+++ b/recipes-mono/mono/mono-5.0.1.1.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "48d6ae71d593cd01bf0f499de569359d45856cda325575e1bacb5fabaa7e9718"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 EXTRA_OECONF = "--disable-btls"

--- a/recipes-mono/mono/mono-5.10.1.47.inc
+++ b/recipes-mono/mono/mono-5.10.1.47.inc
@@ -1,3 +1,3 @@
 SRC_URI[sha256sum] = "90c237b5288f95f6fdab4ace1e36ab64a6369e2c9fddd462d604fd788e2545da"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"

--- a/recipes-mono/mono/mono-5.12.0.226.inc
+++ b/recipes-mono/mono/mono-5.12.0.226.inc
@@ -1,3 +1,3 @@
 SRC_URI[sha256sum] = "f0636baa0c1399805526142e799cb697ddccf736e506cf1a30a870eaa2830a89"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"

--- a/recipes-mono/mono/mono-5.14.0.177.inc
+++ b/recipes-mono/mono/mono-5.14.0.177.inc
@@ -1,3 +1,3 @@
 SRC_URI[sha256sum] = "d4f5fa2e8188d66fbc8054f4145711e45c1faa6d070e63600efab93d1d189498"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"

--- a/recipes-mono/mono/mono-5.16.0.179.inc
+++ b/recipes-mono/mono/mono-5.16.0.179.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "93839af2ef0b8796935d8c1efd4cc693bc294bb2beb657b9edb6b4764f01e12b"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-5.16.0.220.inc
+++ b/recipes-mono/mono/mono-5.16.0.220.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "f420867232b426c062fa182256a66b29efa92992c119847359cdd1ab75af8de3"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-5.16.1.0.inc
+++ b/recipes-mono/mono/mono-5.16.1.0.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "c2074249d8c090bac56c38e1fcbdbe215703403a0fbeccf6db7c04d8033c8537"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-5.18.0.225.inc
+++ b/recipes-mono/mono/mono-5.18.0.225.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "91aa3e8a12aaf94760a092866abc5c5f1f437ecd0a97bedfff857c439aa7a87f"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-5.18.0.240.inc
+++ b/recipes-mono/mono/mono-5.18.0.240.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "143e80eb00519ff496742e78ee07403a3c3629437f3a498eee539de8108da895"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-5.18.0.268.inc
+++ b/recipes-mono/mono/mono-5.18.0.268.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "04ee081482b2f3e37ab7e2f92e2127e9e7b63211dbaa364e5b22b227a6b1bb8c"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-5.18.1.0.inc
+++ b/recipes-mono/mono/mono-5.18.1.0.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "a92a8fb54f8faa922cdb203cf0bee93bf418f08144f5bc018c5013948d03a4f0"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-5.18.1.28.inc
+++ b/recipes-mono/mono/mono-5.18.1.28.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "3e0368a85ebd2c6f75b0ad928a81b6530b5a4299ff191389d3dd0bf893d12d31"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-5.2.0.175.inc
+++ b/recipes-mono/mono/mono-5.2.0.175.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "cd00cc9d582449853b861419fa5647c0c2174e7fc07b2aeb03ba5ca847da4b18"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 EXTRA_OECONF = "--disable-btls"

--- a/recipes-mono/mono/mono-5.2.0.179.inc
+++ b/recipes-mono/mono/mono-5.2.0.179.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "b5325302000ae992221e46ad9d5d8393aae92a5db7fbef7993d958805d307257"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 EXTRA_OECONF = "--disable-btls"

--- a/recipes-mono/mono/mono-5.2.0.196.inc
+++ b/recipes-mono/mono/mono-5.2.0.196.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "731634b24c89680660fed1efd63a39ec6c052e519ae9a2dce61f875598329366"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 EXTRA_OECONF = "--disable-btls"

--- a/recipes-mono/mono/mono-5.2.0.215.inc
+++ b/recipes-mono/mono/mono-5.2.0.215.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "8f0cebd3f7b03f68b9bd015706da9c713ed968004612f1ef8350993d8fe850ea"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 EXTRA_OECONF = "--disable-btls"

--- a/recipes-mono/mono/mono-5.2.0.224.inc
+++ b/recipes-mono/mono/mono-5.2.0.224.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "03b8e463032bc425673dec844b35b4c669f5b99b0e45521195efb3741a9f5e94"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 EXTRA_OECONF = "--disable-btls"

--- a/recipes-mono/mono/mono-5.20.1.34.inc
+++ b/recipes-mono/mono/mono-5.20.1.34.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "cd91d44cf62515796ba90dfdc274bb33471c25a2f1a262689a3bdc0a672b7c8b"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-5.4.0.167.inc
+++ b/recipes-mono/mono/mono-5.4.0.167.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "c2afe51b0fb074936a8e7eaee805c352f37cbf1093bb41c5345078f77d913ce0"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 EXTRA_OECONF = "--disable-btls"

--- a/recipes-mono/mono/mono-5.4.0.201.inc
+++ b/recipes-mono/mono/mono-5.4.0.201.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "2a2f5c2a214a9980c086ac7561a5dd106f13d823a630de218eabafe1d995c5b4"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-5.4.0.56.inc
+++ b/recipes-mono/mono/mono-5.4.0.56.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "f3e2c071e1bd5336b529a9e2a24d3bf348b7f54dcb7e6bee9a22d8abe42fce47"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 EXTRA_OECONF = "--disable-btls"

--- a/recipes-mono/mono/mono-5.4.1.6.inc
+++ b/recipes-mono/mono/mono-5.4.1.6.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "bdfda0fe9ad5ce20bb2cf9e9bf28fed40f324141297479824e1f65d97da565df"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-5.8.0.129.inc
+++ b/recipes-mono/mono/mono-5.8.0.129.inc
@@ -1,3 +1,3 @@
 SRC_URI[sha256sum] = "c9c6a53a498fd1c28f901f797f9f6706b961b262d2eebd2ce41f004b0173e35f"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"

--- a/recipes-mono/mono/mono-5.8.0.22.inc
+++ b/recipes-mono/mono/mono-5.8.0.22.inc
@@ -1,3 +1,3 @@
 SRC_URI[sha256sum] = "2a2f98299dfff2d0ba0c5c48868f9a974456088fe0055b1c7a8c587f5301ccac"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"

--- a/recipes-mono/mono/mono-5.xx.inc
+++ b/recipes-mono/mono/mono-5.xx.inc
@@ -30,7 +30,7 @@ def mono_workspace_version (d):
     else:
         return 0
 
-S = "${WORKDIR}/mono-${@mono_workspace_version(d)}"
+S = "${UNPACKDIR}/mono-${@mono_workspace_version(d)}"
 
 FILESPATH =. "${FILE_DIRNAME}/mono-5.xx:"
 FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"

--- a/recipes-mono/mono/mono-6.10.0.104.inc
+++ b/recipes-mono/mono/mono-6.10.0.104.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "b8d6eb70a252d2efad8384d66b529883dc59e581565d617fa57f8e79317e332c"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-6.12.0.107.inc
+++ b/recipes-mono/mono/mono-6.12.0.107.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "61f3cd629f8e99371c6b47c1f8d96b8ac46d9e851b5531eef20cdf9ab60d2a5f"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-6.12.0.122.inc
+++ b/recipes-mono/mono/mono-6.12.0.122.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "29c277660fc5e7513107aee1cbf8c5057c9370a4cdfeda2fc781be6986d89d23"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-6.12.0.147.inc
+++ b/recipes-mono/mono/mono-6.12.0.147.inc
@@ -1,7 +1,7 @@
 BASEPV = "6.12.0.122"
 SRC_URI[sha256sum] = "29c277660fc5e7513107aee1cbf8c5057c9370a4cdfeda2fc781be6986d89d23"
 
-S = "${WORKDIR}/mono-${BASEPV}"
+S = "${UNPACKDIR}/mono-${BASEPV}"
 
 DEPENDS += " cmake-native"
 

--- a/recipes-mono/mono/mono-6.12.0.154.inc
+++ b/recipes-mono/mono/mono-6.12.0.154.inc
@@ -1,7 +1,7 @@
 BASEPV = "6.12.0.122"
 SRC_URI[sha256sum] = "29c277660fc5e7513107aee1cbf8c5057c9370a4cdfeda2fc781be6986d89d23"
 
-S = "${WORKDIR}/mono-${BASEPV}"
+S = "${UNPACKDIR}/mono-${BASEPV}"
 
 DEPENDS += " cmake-native"
 

--- a/recipes-mono/mono/mono-6.12.0.161.inc
+++ b/recipes-mono/mono/mono-6.12.0.161.inc
@@ -1,7 +1,7 @@
 BASEPV = "6.12.0.122"
 SRC_URI[sha256sum] = "29c277660fc5e7513107aee1cbf8c5057c9370a4cdfeda2fc781be6986d89d23"
 
-S = "${WORKDIR}/mono-${BASEPV}"
+S = "${UNPACKDIR}/mono-${BASEPV}"
 
 DEPENDS += "cmake-native"
 

--- a/recipes-mono/mono/mono-6.12.0.182.inc
+++ b/recipes-mono/mono/mono-6.12.0.182.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "57366a6ab4f3b5ecf111d48548031615b3a100db87c679fc006e8c8a4efd9424"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-6.12.0.182/0001-patch-XplatUIX11-cursor.diff
+++ b/recipes-mono/mono/mono-6.12.0.182/0001-patch-XplatUIX11-cursor.diff
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
 diff -ur mono-6.8.0.96.org/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs mono-6.8.0.96/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
 --- mono-6.8.0.96.org/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs	2020-01-15 07:46:01.000000000 +0000
 +++ mono-6.8.0.96/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs	2020-02-08 21:22:11.059830600 +0000

--- a/recipes-mono/mono/mono-6.12.0.182/disable-mmap-MAP_32BIT-support.patch
+++ b/recipes-mono/mono/mono-6.12.0.182/disable-mmap-MAP_32BIT-support.patch
@@ -8,6 +8,8 @@ kernels. Disable MAP_32BIT support for now.
 
 Reference: https://lore.kernel.org/linux-mm/cb8dc31a-fef2-1d09-f133-e9f7b9f9e77a@sony.com/
 Reference: https://lore.kernel.org/all/20230414185919.4175572-1-Liam.Howlett@oracle.com/T/#m00a0ac8a72bf2f26711b7f8cc56612a8ef62c3d0
+
+Upstream-Status: Inappropriate [Yocto specific]
 ---
  mono/mini/mini-amd64.h    | 2 --
  mono/utils/mono-codeman.c | 4 ----

--- a/recipes-mono/mono/mono-6.12.0.182/shm_open-test-crosscompile.diff
+++ b/recipes-mono/mono/mono-6.12.0.182/shm_open-test-crosscompile.diff
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
 --- mono-6.8.0.96/configure.ac.orig	2019-03-15 10:45:13.000000000 -0400
 +++ mono-6.8.0.96/configure.ac	2019-03-19 08:00:53.815148109 -0400
 @@ -3264,6 +3264,9 @@

--- a/recipes-mono/mono/mono-6.8.0.105.inc
+++ b/recipes-mono/mono/mono-6.8.0.105.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "578799c44c3c86a9eb5daf6dec6c60a24341940fd376371956d4a46cf8612178"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-6.8.0.123.inc
+++ b/recipes-mono/mono/mono-6.8.0.123.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "e2e42d36e19f083fc0d82f6c02f7db80611d69767112af353df2f279744a2ac5"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-6.8.0.96.inc
+++ b/recipes-mono/mono/mono-6.8.0.96.inc
@@ -1,5 +1,5 @@
 SRC_URI[sha256sum] = "ed5df4ec663a4e228e89e910e954fa18d33f72e790c11174e1b62fc8cca90ba0"
 
-S = "${WORKDIR}/mono-${PV}"
+S = "${UNPACKDIR}/mono-${PV}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-6.xx.inc
+++ b/recipes-mono/mono/mono-6.xx.inc
@@ -22,7 +22,7 @@ def mono_workspace_version (d):
     pvsplit = d.getVar('PV',d,1).split('.')
     return pvsplit[0] + '.' + pvsplit[1] + '.' + pvsplit[2]
 
-S = "${WORKDIR}/mono-${@mono_workspace_version(d)}"
+S = "${UNPACKDIR}/mono-${@mono_workspace_version(d)}"
 
 FILESPATH =. "${FILE_DIRNAME}/mono-6.xx:"
 FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"

--- a/recipes-mono/mono/mono-git.inc
+++ b/recipes-mono/mono/mono-git.inc
@@ -23,7 +23,7 @@ SRC_URI = "git://github.com/mono/mono.git;branch=${SRCBRANCH}\
 #	   file://0001-reintroduce-gmcs.patch \
 #
 
-S = "${WORKDIR}/git"
+S = "${UNPACKDIR}/git"
 
 FILESPATH =. "${FILE_DIRNAME}/mono-4.xx:"
 FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"

--- a/recipes-mono/mono/mono-native_4.0.1.28.bb
+++ b/recipes-mono/mono/mono-native_4.0.1.28.bb
@@ -8,7 +8,7 @@ PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)}
 
 SRC_URI += "file://fix-basic-mscorlib-dep.patch"
 
-S = "${WORKDIR}/mono-4.0.1"
+S = "${UNPACKDIR}/mono-4.0.1"
 
 inherit native
 

--- a/recipes-mono/mono/mono-native_4.0.1.34.bb
+++ b/recipes-mono/mono/mono-native_4.0.1.34.bb
@@ -10,7 +10,7 @@ SRC_URI += "file://fix-basic-mscorlib-dep.patch \
 	    file://0001-add-missing-visualbasic-targets.patch \
 "
 
-S = "${WORKDIR}/mono-4.0.1"
+S = "${UNPACKDIR}/mono-4.0.1"
 
 inherit native
 

--- a/recipes-mono/mono/mono_4.0.1.28.bb
+++ b/recipes-mono/mono/mono_4.0.1.28.bb
@@ -5,7 +5,7 @@ DEPENDS = "mono-native"
 
 EXTRA_OECONF += "--disable-mcs-build mono_cv_clang=no mono_cv_uscore=no --with-sigaltstack=no --with-mcs-docs=no"
 
-S = "${WORKDIR}/${PN}-4.0.1"
+S = "${UNPACKDIR}/${PN}-4.0.1"
 
 do_install:append() {
         cp -af ${STAGING_DIR_NATIVE}${sysconfdir}/${PN} ${D}${sysconfdir}

--- a/recipes-mono/mono/mono_4.0.1.34.bb
+++ b/recipes-mono/mono/mono_4.0.1.34.bb
@@ -5,7 +5,7 @@ DEPENDS = "mono-native"
 
 EXTRA_OECONF += "--disable-mcs-build mono_cv_clang=no mono_cv_uscore=no --with-sigaltstack=no --with-mcs-docs=no"
 
-S = "${WORKDIR}/${PN}-4.0.1"
+S = "${UNPACKDIR}/${PN}-4.0.1"
 
 do_install:append() {
         cp -af ${STAGING_DIR_NATIVE}${sysconfdir}/${PN} ${D}${sysconfdir}

--- a/recipes-mono/monotools-server/monotools-server_2.0.bb
+++ b/recipes-mono/monotools-server/monotools-server_2.0.bb
@@ -26,7 +26,7 @@ SRC_URI += " \
 
 DEPENDS = "mono-xsp gtk-sharp"
 
-S = "${WORKDIR}/${PN}"
+S = "${UNPACKDIR}/${PN}"
 
 inherit autotools-brokensep gettext pkgconfig
 

--- a/recipes-mono/msbuild/msbuild-16.10.1/0001-Copy-hostfxr.patch
+++ b/recipes-mono/msbuild/msbuild-16.10.1/0001-Copy-hostfxr.patch
@@ -3,6 +3,7 @@ From: Nicolas Jeker <n.jeker@gmx.net>
 Date: Fri, 22 Jan 2021 10:41:27 +0100
 Subject: [PATCH] Copy hostfxr
 
+Upstream-Status: Inappropriate [Yocto specific]
 ---
  eng/cibuild_bootstrapped_msbuild.sh | 1 +
  1 file changed, 1 insertion(+)

--- a/recipes-mono/msbuild/msbuild-16.10.1/mono-msbuild-use-bash.patch
+++ b/recipes-mono/msbuild/msbuild-16.10.1/mono-msbuild-use-bash.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
 Index: xamarin-pkg-msbuild/gen_build_info.sh
 ===================================================================
 --- xamarin-pkg-msbuild.orig/gen_build_info.sh

--- a/recipes-mono/msbuild/msbuild/0001-Copy-hostfxr.patch
+++ b/recipes-mono/msbuild/msbuild/0001-Copy-hostfxr.patch
@@ -3,6 +3,7 @@ From: Nicolas Jeker <n.jeker@gmx.net>
 Date: Fri, 22 Jan 2021 10:41:27 +0100
 Subject: [PATCH] Copy hostfxr
 
+Upstream-Status: Inappropriate [Yocto specific]
 ---
  eng/cibuild_bootstrapped_msbuild.sh | 1 +
  1 file changed, 1 insertion(+)

--- a/recipes-mono/msbuild/msbuild/0001-Don-t-try-to-run-pkill.patch
+++ b/recipes-mono/msbuild/msbuild/0001-Don-t-try-to-run-pkill.patch
@@ -3,6 +3,7 @@ From: Nicolas Jeker <n.jeker@delisys.ch>
 Date: Fri, 6 Nov 2020 11:19:38 +0100
 Subject: [PATCH] Don't try to run pkill
 
+Upstream-Status: Inappropriate [Yocto specific]
 ---
  eng/cibuild_bootstrapped_msbuild.sh | 2 --
  1 file changed, 2 deletions(-)

--- a/recipes-mono/msbuild/msbuild/0002-Remove-myget-feeds-and-replace-with-AzDO-feeds.patch
+++ b/recipes-mono/msbuild/msbuild/0002-Remove-myget-feeds-and-replace-with-AzDO-feeds.patch
@@ -3,6 +3,7 @@ From: =?UTF-8?q?Alexander=20K=C3=B6plinger?= <alex.koeplinger@outlook.com>
 Date: Fri, 15 Jan 2021 12:39:49 +0100
 Subject: [PATCH] Remove myget feeds and replace with AzDO feeds
 
+Upstream-Status: Inappropriate [Yocto specific]
 ---
  NuGet.config | 18 +++---------------
  1 file changed, 3 insertions(+), 15 deletions(-)

--- a/recipes-mono/msbuild/msbuild/cibuild.sh-debug.patch
+++ b/recipes-mono/msbuild/msbuild/cibuild.sh-debug.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
 diff --git a/cibuild.sh b/cibuild.sh
 index 82a3694..5278b35 100755
 --- a/cibuild.sh

--- a/recipes-mono/msbuild/msbuild/mono-msbuild-dotnetbits-case.patch
+++ b/recipes-mono/msbuild/msbuild/mono-msbuild-dotnetbits-case.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
 Index: xamarin-pkg-msbuild/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj
 ===================================================================
 --- xamarin-pkg-msbuild.orig/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj

--- a/recipes-mono/msbuild/msbuild/mono-msbuild-license-case.patch
+++ b/recipes-mono/msbuild/msbuild/mono-msbuild-license-case.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
 Index: xamarin-pkg-msbuild/LICENSE
 ===================================================================
 --- xamarin-pkg-msbuild.orig/LICENSE

--- a/recipes-mono/msbuild/msbuild/mono-msbuild-no-hostfxr.patch
+++ b/recipes-mono/msbuild/msbuild/mono-msbuild-no-hostfxr.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
 diff -rupN mono-msbuild.orig/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj mono-msbuild/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj
 --- mono-msbuild.orig/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj	2020-07-03 19:37:07.112979921 +0200
 +++ mono-msbuild/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj	2020-07-03 19:37:59.966877151 +0200

--- a/recipes-mono/msbuild/msbuild/mono-msbuild-use-bash.patch
+++ b/recipes-mono/msbuild/msbuild/mono-msbuild-use-bash.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
 Index: xamarin-pkg-msbuild/gen_build_info.sh
 ===================================================================
 --- xamarin-pkg-msbuild.orig/gen_build_info.sh

--- a/recipes-mono/msbuild/msbuild/mono-msbuild-use-more-bash.patch
+++ b/recipes-mono/msbuild/msbuild/mono-msbuild-use-more-bash.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
 diff --git a/mono/build/extract_and_copy_hostfxr.sh b/mono/build/extract_and_copy_hostfxr.sh
 index 68a8586..8fae00b 100755
 --- a/mono/build/extract_and_copy_hostfxr.sh

--- a/recipes-mono/msbuild/msbuild_15.4.bb
+++ b/recipes-mono/msbuild/msbuild_15.4.bb
@@ -18,7 +18,7 @@ SRC_URI = " \
 			file://cibuild.sh-debug.patch \
 		"
 
-S = "${WORKDIR}/git"
+S = "${UNPACKDIR}/git"
 
 do_compile () {
 	./cibuild.sh --scope Compile --host Mono --target Mono --config Release --bootstrap-only

--- a/recipes-mono/msbuild/msbuild_16.10.1.bb
+++ b/recipes-mono/msbuild/msbuild_16.10.1.bb
@@ -41,8 +41,8 @@ export CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt"
 do_compile[network] = "1"
 
 do_compile () {
-    mkdir -p ${WORKDIR}/build-home-dir
-    export HOME=${WORKDIR}/build-home-dir
+    mkdir -p ${UNPACKDIR}/build-home-dir
+    export HOME=${UNPACKDIR}/build-home-dir
 
     # Sync Mono certificate store with ca-certificates
     cert-sync --user ${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt
@@ -57,7 +57,7 @@ do_compile () {
 }
 
 do_install () {
-    export HOME=${WORKDIR}/build-home-dir
+    export HOME=${UNPACKDIR}/build-home-dir
 
     ./stage1/mono-msbuild/msbuild mono/build/install.proj /p:MonoInstallPrefix="${D}" /p:Configuration=Release-MONO /p:IgnoreDiffFailure=true
 }

--- a/recipes-mono/msbuild/msbuild_16.10.1.bb
+++ b/recipes-mono/msbuild/msbuild_16.10.1.bb
@@ -21,7 +21,7 @@ SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git;branch=main;protoco
            file://0001-Copy-hostfxr.patch \
            "
 
-S = "${WORKDIR}/git"
+S = "${UNPACKDIR}/git"
 
 do_configure () {
     sed "s|%libhostfxr%|${STAGING_DIR_TARGET}${libdir}/libhostfxr.so|g" -i ${S}/eng/cibuild_bootstrapped_msbuild.sh

--- a/recipes-mono/msbuild/msbuild_16.6.bb
+++ b/recipes-mono/msbuild/msbuild_16.6.bb
@@ -24,7 +24,7 @@ SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git;branch=main;protoco
            file://0002-Remove-myget-feeds-and-replace-with-AzDO-feeds.patch \
            "
 
-S = "${WORKDIR}/git"
+S = "${UNPACKDIR}/git"
 
 do_configure () {
     sed "s|%libhostfxr%|${STAGING_DIR_TARGET}${libdir}/libhostfxr.so|g" -i ${S}/eng/cibuild_bootstrapped_msbuild.sh

--- a/recipes-mono/nuget/nuget.inc
+++ b/recipes-mono/nuget/nuget.inc
@@ -19,16 +19,15 @@ SRC_URI = " \
 
 SRC_URI[lic.sha256sum] = "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30"
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
+S = "${UNPACKDIR}"
 
 do_install () {
 	install -d -m0755 ${D}${bindir}
-	install -m0755 ${UNPACKDIR}/nuget.sh.in ${D}${bindir}/nuget
+	install -m0755 ${S}/nuget.sh.in ${D}${bindir}/nuget
 	sed -i -e 's:@bindir@:${bindir}:g' -e 's:@libdir@:${libdir}:g' ${D}${bindir}/nuget
 
 	install -d -m0755 ${D}${libdir}/mono/nuget
-	install -m0755 ${UNPACKDIR}/NuGet-v${PV}.exe ${D}${libdir}/mono/nuget/NuGet.exe
+	install -m0755 ${S}/NuGet-v${PV}.exe ${D}${libdir}/mono/nuget/NuGet.exe
 }
 
 FILES:${PN} += "${libdir}/mono/nuget"
@@ -37,7 +36,7 @@ SYSROOT_PREPROCESS_FUNCS += "nuget_sysroot_preprocess"
 
 nuget_sysroot_preprocess () {
 	install -d -m0755 ${SYSROOT_DESTDIR}${bindir_crossscripts}/
-	install -m0755 ${UNPACKDIR}/nuget.sh.in ${SYSROOT_DESTDIR}${bindir_crossscripts}/nuget
+	install -m0755 ${S}/nuget.sh.in ${SYSROOT_DESTDIR}${bindir_crossscripts}/nuget
 	sed -i -e 's:@bindir@:${STAGING_BINDIR_NATIVE}:g' -e 's:@libdir@:${STAGING_LIBDIR}:g' ${SYSROOT_DESTDIR}${bindir_crossscripts}/nuget
 }
 

--- a/recipes-mono/nuget/nuget.inc
+++ b/recipes-mono/nuget/nuget.inc
@@ -19,15 +19,16 @@ SRC_URI = " \
 
 SRC_URI[lic.sha256sum] = "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 do_install () {
 	install -d -m0755 ${D}${bindir}
-	install -m0755 ${WORKDIR}/nuget.sh.in ${D}${bindir}/nuget
+	install -m0755 ${UNPACKDIR}/nuget.sh.in ${D}${bindir}/nuget
 	sed -i -e 's:@bindir@:${bindir}:g' -e 's:@libdir@:${libdir}:g' ${D}${bindir}/nuget
 
 	install -d -m0755 ${D}${libdir}/mono/nuget
-	install -m0755 ${WORKDIR}/NuGet-v${PV}.exe ${D}${libdir}/mono/nuget/NuGet.exe
+	install -m0755 ${UNPACKDIR}/NuGet-v${PV}.exe ${D}${libdir}/mono/nuget/NuGet.exe
 }
 
 FILES:${PN} += "${libdir}/mono/nuget"
@@ -36,7 +37,7 @@ SYSROOT_PREPROCESS_FUNCS += "nuget_sysroot_preprocess"
 
 nuget_sysroot_preprocess () {
 	install -d -m0755 ${SYSROOT_DESTDIR}${bindir_crossscripts}/
-	install -m0755 ${WORKDIR}/nuget.sh.in ${SYSROOT_DESTDIR}${bindir_crossscripts}/nuget
+	install -m0755 ${UNPACKDIR}/nuget.sh.in ${SYSROOT_DESTDIR}${bindir_crossscripts}/nuget
 	sed -i -e 's:@bindir@:${STAGING_BINDIR_NATIVE}:g' -e 's:@libdir@:${STAGING_LIBDIR}:g' ${SYSROOT_DESTDIR}${bindir_crossscripts}/nuget
 }
 

--- a/recipes-mono/taglib-sharp/taglib-sharp.inc
+++ b/recipes-mono/taglib-sharp/taglib-sharp.inc
@@ -10,7 +10,7 @@ DEPENDS = "mono"
 
 SRC_URI = "git://github.com/mono/taglib-sharp.git;protocol=https;branch=${SRCBRANCH}"
 
-S = "${WORKDIR}/git"
+S = "${UNPACKDIR}/git"
 
 inherit autotools-brokensep pkgconfig
 

--- a/recipes-python/python3-clr-loader/python3-clr-loader.bb
+++ b/recipes-python/python3-clr-loader/python3-clr-loader.bb
@@ -17,13 +17,13 @@ DOTNET_MIN_REQ_VERSION ?= "6.0.0"
 
 DEPENDS += " \
     dotnet-native (>= ${DOTNET_MIN_REQ_VERSION}) \
-    ${PYTHON_PN}-setuptools-scm-native \
-    ${PYTHON_PN}-toml-native \
+    python3-setuptools-scm-native \
+    python3-toml-native \
 "
 
 RDEPENDS:${PN} += " \
     dotnet (>= ${DOTNET_MIN_REQ_VERSION}) \
-    ${PYTHON_PN}-cffi \
+    python3-cffi \
 "
 
 # NuGet uses $HOME/.nuget/packages to store packages by default

--- a/recipes-python/python3-clr-loader/python3-clr-loader.bb
+++ b/recipes-python/python3-clr-loader/python3-clr-loader.bb
@@ -28,9 +28,9 @@ RDEPENDS:${PN} += " \
 
 # NuGet uses $HOME/.nuget/packages to store packages by default
 # but we should not use anything outside the build root of packages.
-# Use a separated folder for nuget downloads and cache in WORKDIR.
-export NUGET_PACKAGES="${WORKDIR}/nuget-packages"
-export NUGET_HTTP_CACHE_PATH="${WORKDIR}/nuget-http-cache"
+# Use a separated folder for nuget downloads and cache in UNPACKDIR.
+export NUGET_PACKAGES="${UNPACKDIR}/nuget-packages"
+export NUGET_HTTP_CACHE_PATH="${UNPACKDIR}/nuget-http-cache"
 
 # Workaround for dotnet restore issue, define custom proxy in a .bbappend
 # and/or in layer.conf or local.conf if dotnet restore was failed.

--- a/recipes-python/python3-pythonnet/python3-pythonnet.bb
+++ b/recipes-python/python3-pythonnet/python3-pythonnet.bb
@@ -37,9 +37,9 @@ RDEPENDS:${PN} += " \
 
 # NuGet uses $HOME/.nuget/packages to store packages by default
 # but we should not use anything outside the build root of packages.
-# Use a separated folder for nuget downloads and cache in WORKDIR.
-export NUGET_PACKAGES="${WORKDIR}/nuget-packages"
-export NUGET_HTTP_CACHE_PATH="${WORKDIR}/nuget-http-cache"
+# Use a separated folder for nuget downloads and cache in UNPACKDIR.
+export NUGET_PACKAGES="${UNPACKDIR}/nuget-packages"
+export NUGET_HTTP_CACHE_PATH="${UNPACKDIR}/nuget-http-cache"
 
 # Workaround for dotnet restore issue, define custom proxy in a .bbappend
 # and/or in layer.conf or local.conf if dotnet restore was failed.
@@ -59,8 +59,8 @@ do_configure:prepend() {
 do_compile[network] = "1"
 
 do_install:prepend() {
-    printf "${PYTHONNET_ENV}" > ${WORKDIR}/dotnet-env.sh
+    printf "${PYTHONNET_ENV}" > ${UNPACKDIR}/dotnet-env.sh
 
     install -d ${D}${sysconfdir}/profile.d
-    install -m 644 ${WORKDIR}/dotnet-env.sh    ${D}${sysconfdir}/profile.d
+    install -m 644 ${UNPACKDIR}/dotnet-env.sh    ${D}${sysconfdir}/profile.d
 }

--- a/recipes-python/python3-pythonnet/python3-pythonnet.bb
+++ b/recipes-python/python3-pythonnet/python3-pythonnet.bb
@@ -23,16 +23,16 @@ PYTHONNET_ENV = "#!/bin/bash\n\nexport PYTHONNET_RUNTIME=${PYTHONNET_DEFAULT_RUN
 
 DEPENDS += " \
     dotnet-native (>= ${DOTNET_MIN_REQ_VERSION}) \
-    ${PYTHON_PN}-clr-loader-native \
-    ${PYTHON_PN}-setuptools-scm-native \
-    ${PYTHON_PN}-toml-native \
+    python3-clr-loader-native \
+    python3-setuptools-scm-native \
+    python3-toml-native \
 "
 
 RDEPENDS:${PN} += " \
     bash \
     dotnet (>= ${DOTNET_MIN_REQ_VERSION}) \
-    ${PYTHON_PN}-pycparser \
-    ${PYTHON_PN}-clr-loader \
+    python3-pycparser \
+    python3-clr-loader \
 "
 
 # NuGet uses $HOME/.nuget/packages to store packages by default


### PR DESCRIPTION
This is a rebase of #225 over current master.

In the meantime, the styhead branches were created in upstream Yocto and [styhead already diverged from current master](https://lists.openembedded.org/g/openembedded-core/message/205173) leading to Yocto 5.2 "Walnascar".

I added the necessary CI change to use the styhead branch from poky. Not sure if this also uses (the currently non-existing) styhead branch from meta-mono, or as intended, its master branch.