### PR TITLE
Fix native libdir path for multilib

### DIFF
--- a/recipes-mono/mono/mono-base.inc
+++ b/recipes-mono/mono/mono-base.inc
@@ -37,9 +37,9 @@ do_compile() {
 do_install:append() {
         install -d ${D}${libdir}/${PN}
         for lib in ${MONOLIBS}; do
-            if [ -d "${STAGING_DIR_NATIVE}${libdir}/${PN}/$lib" ]; then
+            if [ -d "${STAGING_LIBDIR_NATIVE}/${PN}/$lib" ]; then
                 cp -af --no-preserve=ownership \
-                    ${STAGING_DIR_NATIVE}${libdir}/${PN}/$lib ${D}${libdir}/${PN}
+                    ${STAGING_LIBDIR_NATIVE}/${PN}/$lib ${D}${libdir}/${PN}
             fi
         done
         # AJL - Remove mscorlib.dll.so and mcs.exe.so files copied from mono-native to the mono destination


### PR DESCRIPTION
Closes #238 

When building for an image with multilib (for 32 bit x86), the `${libdir}` variable gets changed from `/usr/lib` to `/usr/lib64` - but `mono-native` still outputs the libraries into `/usr/lib`.
This is one approach that fixes that issue.

Note: this also should be backported as far back as Kirkstone, maybe further - I dunno what your workflow for that is.