### PR TITLE
mono: fix RDEPENDS for mono-4.xx

### DIFF
--- a/recipes-mono/mono/mono-4.xx.inc
+++ b/recipes-mono/mono/mono-4.xx.inc
@@ -90,7 +90,7 @@ FILES:${PN}-doc				+= " ${datadir}/libgc-mono/*"
 FILES:${PN}-dbg				+= " ${datadir}/mono-2.0/mono/cil/cil-opcodes.xml ${libdir}/mono/*/*.mdb ${libdir}/mono/gac/*/*/*.mdb"
 FILES:${PN}-staticdev			+= " ${libdir}/*.a"
 
-RDEPENDS:${PN} =+ "bash" 
+RDEPENDS:${PN}-dev =+ "bash"
 
 # Workaround for observed race in `make install`
 PARALLEL_MAKEINST=""


### PR DESCRIPTION
It seems that at some point, the script was moved from the base package, to the `-dev` package. I haven't tested every 4.xx package, but I did try `4.0.2.4`, and the build went through fine, and I can see that this change was also made in 5.xx, so I assume all of 4.xx should have it as well.

Fixes the following error:
```
ERROR: mono-4.6.1.5-r0 do_package_qa: QA Issue: /usr/bin/mono-find-requires contained in package mono-dev requires /bin/bash, but no providers found in RDEPENDS:mono-dev? [file-rdeps]
ERROR: mono-4.6.1.5-r0 do_package_qa: Fatal QA errors were found, failing task.
```