### PR TITLE
layer.conf: set dotnet 10.0.100 as default preferred version

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -13,6 +13,9 @@ BBFILE_PRIORITY_mono = "5"
 PREFERRED_VERSION_mono ?= "6.12.0.206"
 PREFERRED_VERSION_mono-native ?= "6.12.0.206"
 
+PREFERRED_VERSION_dotnet ?= "10.0.100"
+PREFERRED_VERSION_dotnet-native ?= "10.0.100"
+
 PREFERRED_VERSION_libgdiplus ?= "6.0.5"
 PREFERRED_VERSION_libgdiplus-native ?= "6.0.5"
 


### PR DESCRIPTION
Add PREFERRED_VERSION_dotnet and PREFERRED_VERSION_dotnet-native defaulting to 10.0.100 (.NET 10) now that the recipe is available. Uses weak assignment (?=) so users can override in local.conf.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Conf-only change that only adjusts default recipe version selection; impact is limited to which `dotnet` version gets built by default.
> 
> **Overview**
> Sets default Yocto `PREFERRED_VERSION_dotnet` and `PREFERRED_VERSION_dotnet-native` in `conf/layer.conf` to `10.0.100` using weak assignment (`?=`), so builds in this layer prefer .NET 10 unless a downstream config overrides it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6590d905cf716d9e7b94f2d7c14de04c2b1b1e86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->