### PR TITLE
Update release support: whinlatter, remove EOL branches

### DIFF
--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-      - feature/yocto-layer-compliance
+      - whinlatter
   pull_request:
     branches:
       - master
-      - feature/yocto-layer-compliance
+      - whinlatter
     paths-ignore:
       - "**.md"
 jobs:
@@ -23,11 +23,11 @@ jobs:
       matrix:
         dotnet_version: [10.0.100, 8.0.406, 6.0.428]
         mono_version: [6.12.0.206]
-        branch: [styhead]
+        branch: [whinlatter]
         arch: [x86-64, arm, arm64]
         exclude:
-          # styhead GCC build broken for ARM32 - see README "Removal of support for ARM32" and discussions/234
-          - branch: styhead
+          # GCC build broken for ARM32 - see README and discussions/234
+          - branch: whinlatter
             arch: arm
     env:
       name: build-and-test

--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@ meta-mono is an OpenEmbedded layer that builds dotNet, the mono runtime and mono
 
 | Branch | Version | Support Status* | Status of Build & Tests |
 | ------ | ------- | --------------- | ----------------------- |
-| walnascar | 5.2	| Future (April 2025) | [![walnascar](https://img.shields.io/github/actions/workflow/status/dynamicdevices/meta-mono/CI_github.yml?branch=walnascar&label=build%20%26%20test)](https://github.com/DynamicDevices/meta-mono/actions/workflows/CI_github.yml) |
-| styhead   | 5.1	| Support for 7 months (May 2025) | [![styhead](https://img.shields.io/github/actions/workflow/status/dynamicdevices/meta-mono/CI_github.yml?branch=styhead&label=build%20%26%20test)](https://github.com/DynamicDevices/meta-mono/actions/workflows/CI_github.yml) |
-| scarthgap | 5.0	| Long Term Support (until Apr. 2028) | [![scarthgap](https://img.shields.io/github/actions/workflow/status/dynamicdevices/meta-mono/CI_github.yml?branch=scarthgap&label=build%20%26%20test)](https://github.com/DynamicDevices/meta-mono/actions/workflows/CI_github.yml) |
-| kirkstone | 4.0	| Long Term Support (minimum Apr. 2024)	 | [![kirkstone](https://img.shields.io/github/actions/workflow/status/dynamicdevices/meta-mono/CI_github.yml?branch=kirkstone&label=build%20%26%20test)](https://github.com/DynamicDevices/meta-mono/actions/workflows/CI_github.yml) |
+| whinlatter | 5.3 | Support for 6 months (until May 2026) | [![whinlatter](https://img.shields.io/github/actions/workflow/status/dynamicdevices/meta-mono/CI_github.yml?branch=whinlatter&label=build%20%26%20test)](https://github.com/DynamicDevices/meta-mono/actions/workflows/CI_github.yml) |
+| scarthgap | 5.0 | Long Term Support (until Apr. 2028) | [![scarthgap](https://img.shields.io/github/actions/workflow/status/dynamicdevices/meta-mono/CI_github.yml?branch=scarthgap&label=build%20%26%20test)](https://github.com/DynamicDevices/meta-mono/actions/workflows/CI_github.yml) |
+| kirkstone | 4.0 | Long Term Support (until Apr. 2026) | [![kirkstone](https://img.shields.io/github/actions/workflow/status/dynamicdevices/meta-mono/CI_github.yml?branch=kirkstone&label=build%20%26%20test)](https://github.com/DynamicDevices/meta-mono/actions/workflows/CI_github.yml) |
 
-*support status as of 21/03/25, follows main Yocto release support schedule [here](https://wiki.yoctoproject.org/wiki/Releases)
+*support status as of Feb 2026, follows main Yocto release support schedule [here](https://wiki.yoctoproject.org/wiki/Releases)
 
 ## Limitations
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -30,4 +30,4 @@ INSANE_SKIP:msbuild-dev += "buildpaths"
 INSANE_SKIP:python3-clr-loader += "buildpaths"
 INSANE_SKIP:python3-pythonnet += "buildpaths"
 
-LAYERSERIES_COMPAT_mono = "styhead"
+LAYERSERIES_COMPAT_mono = "whinlatter"


### PR DESCRIPTION
- README: remove walnascar (5.2, EOL Nov 2025) and styhead (5.1, EOL), add whinlatter (5.3, supported until May 2026), fix kirkstone LTS date to Apr. 2026, update status date to Feb 2026
- layer.conf: update LAYERSERIES_COMPAT_mono from styhead to whinlatter
- CI: test against whinlatter poky instead of styhead, remove feature/yocto-layer-compliance branch triggers (merged)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily CI/config/docs updates (branch targets and compatibility metadata) with no runtime code changes; risk is limited to potential CI coverage gaps or incorrect branch targeting.
> 
> **Overview**
> Updates the layer’s declared Yocto compatibility to `whinlatter` and shifts GitHub Actions CI triggers/matrix from `styhead` (and the old compliance feature branch) to building/testing against `whinlatter`.
> 
> Refreshes README release/support information by removing EOL branches, adding `whinlatter`, and updating LTS/support dates and the “as of” timestamp.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e776ddf0f592ede4eb61a211b5c14914ab45c953. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->