### PR TITLE
Yocto 5.3 (whinlatter) migration: CI and recipe updates

### DIFF
--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-      - feature/yocto-layer-compliance
+      - whinlatter
   pull_request:
     branches:
       - master
-      - feature/yocto-layer-compliance
+      - whinlatter
     paths-ignore:
       - "**.md"
 jobs:
@@ -23,12 +23,8 @@ jobs:
       matrix:
         dotnet_version: [10.0.100, 8.0.406, 6.0.428]
         mono_version: [6.12.0.206]
-        branch: [styhead]
-        arch: [x86-64, arm, arm64]
-        exclude:
-          # styhead GCC build broken for ARM32 - see README "Removal of support for ARM32" and discussions/234
-          - branch: styhead
-            arch: arm
+        branch: [whinlatter]
+        arch: [x86-64, arm64]
     env:
       name: build-and-test
       MONO_VERSION: ${{ matrix.mono_version }}
@@ -41,29 +37,41 @@ jobs:
       with:
         clean: false
         path: ${{ matrix.branch }}/meta-mono
-    - name: Update repo poky
+    # Whinlatter (5.3+): poky repo no longer has release branches.
+    # Clone bitbake, openembedded-core and meta-yocto individually.
+    # See: https://docs.yoctoproject.org/dev/migration-guides/migration-5.3.html
+    - name: Clone base layers
       run: |
-        if [ ! -d ${BRANCH}/poky ]; then
-          git clone git://git.yoctoproject.org/poky -b ${BRANCH} ${BRANCH}/poky
-        else
-          cd ${BRANCH}/poky
-          git pull origin ${BRANCH}
-          cd ../..
-        fi
-    - name: Update repo meta-openembedded
+        clone_or_update() {
+          local url="$1" branch="$2" dest="$3"
+          if [ ! -d "$dest" ]; then
+            git clone "$url" -b "$branch" "$dest"
+          else
+            cd "$dest"
+            git fetch origin "$branch"
+            git checkout "$branch"
+            git pull origin "$branch"
+            cd "$GITHUB_WORKSPACE"
+          fi
+        }
+        clone_or_update https://git.openembedded.org/bitbake 2.16 ${BRANCH}/layers/bitbake
+        clone_or_update https://git.openembedded.org/openembedded-core whinlatter ${BRANCH}/layers/openembedded-core
+        clone_or_update https://git.yoctoproject.org/meta-yocto whinlatter ${BRANCH}/layers/meta-yocto
+    - name: Clone meta-openembedded
       run: |
-        if [ ! -d ${BRANCH}/meta-openembedded ]; then
-          git clone https://github.com/openembedded/meta-openembedded.git -b ${BRANCH} ${BRANCH}/meta-openembedded
+        if [ ! -d ${BRANCH}/layers/meta-openembedded ]; then
+          git clone https://github.com/openembedded/meta-openembedded.git -b ${BRANCH} ${BRANCH}/layers/meta-openembedded
         else
-          cd ${BRANCH}/meta-openembedded
+          cd ${BRANCH}/layers/meta-openembedded
           git pull origin ${BRANCH}
-          cd ../..
+          cd "$GITHUB_WORKSPACE"
         fi
     - name: Configuring
       run: |
         rm -f ${BRANCH}/build/conf/local.conf
         rm -f ${BRANCH}/build/conf/bblayers.conf
-        . ./${BRANCH}/poky/oe-init-build-env ${BRANCH}/build
+        TEMPLATECONF=$GITHUB_WORKSPACE/${BRANCH}/layers/meta-yocto/meta-poky/conf/templates/default \
+          . ./${BRANCH}/layers/openembedded-core/oe-init-build-env ${BRANCH}/build
 
         # Append custom variables for regenerated local.conf and bblayers.conf samples
         echo "### Starting to configure local.conf and bblayers.conf ###"
@@ -71,8 +79,8 @@ jobs:
         echo "dotnet version: $DOTNET_VERSION"
 
         echo "BBLAYERS += '$GITHUB_WORKSPACE/${BRANCH}/meta-mono'" >> conf/bblayers.conf
-        echo "BBLAYERS += '$GITHUB_WORKSPACE/${BRANCH}/meta-openembedded/meta-oe'" >> conf/bblayers.conf
-        echo "BBLAYERS += '$GITHUB_WORKSPACE/${BRANCH}/meta-openembedded/meta-python'" >> conf/bblayers.conf
+        echo "BBLAYERS += '$GITHUB_WORKSPACE/${BRANCH}/layers/meta-openembedded/meta-oe'" >> conf/bblayers.conf
+        echo "BBLAYERS += '$GITHUB_WORKSPACE/${BRANCH}/layers/meta-openembedded/meta-python'" >> conf/bblayers.conf
 
         echo "BB_DEFAULT_EVENTLOG = \"\"" >> conf/local.conf
         echo "MACHINE = \"qemu${ARCH}\"" >> conf/local.conf
@@ -95,15 +103,15 @@ jobs:
     # TODO: remove this step once all matrix jobs have rebuilt successfully.
     - name: Clean stale sstate
       run: |
-        . ./${BRANCH}/poky/oe-init-build-env ${BRANCH}/build
+        . ./${BRANCH}/layers/openembedded-core/oe-init-build-env ${BRANCH}/build
         bitbake -c cleansstate dotnet dotnet-native python3-clr-loader python3-clr-loader-native dotnet-helloworld python3-pythonnet
     - name: Building Mono Test Image
       run: |
-        . ./${BRANCH}/poky/oe-init-build-env ${BRANCH}/build
+        . ./${BRANCH}/layers/openembedded-core/oe-init-build-env ${BRANCH}/build
         bitbake test-image-mono
     - name: CVE Check Mono / dotNet
       run: |
-        . ./${BRANCH}/poky/oe-init-build-env ${BRANCH}/build
+        . ./${BRANCH}/layers/openembedded-core/oe-init-build-env ${BRANCH}/build
         export TERM=linux
         bitbake mono -c cve_check
         mv $GITHUB_WORKSPACE/${BRANCH}/build/tmp/log/cve/cve-summary.json $GITHUB_WORKSPACE/${BRANCH}/build/tmp/log/cve/cve-summary-mono.json
@@ -111,7 +119,7 @@ jobs:
         mv $GITHUB_WORKSPACE/${BRANCH}/build/tmp/log/cve/cve-summary.json $GITHUB_WORKSPACE/${BRANCH}/build/tmp/log/cve/cve-summary-dotnet.json
     - name: Testing
       run: |
-        . ./${BRANCH}/poky/oe-init-build-env ${BRANCH}/build
+        . ./${BRANCH}/layers/openembedded-core/oe-init-build-env ${BRANCH}/build
         export TERM=linux
         bitbake test-image-mono -c testimage
     - name: Store artifacts

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -42,6 +42,7 @@ jobs:
     # See: https://docs.yoctoproject.org/dev/migration-guides/migration-5.3.html
     - name: Clone base layers
       run: |
+        mkdir -p "${BRANCH}/layers"
         clone_or_update() {
           local url="$1" branch="$2" dest="$3"
           if [ ! -d "$dest" ]; then

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -60,6 +60,7 @@ jobs:
         clone_or_update https://git.yoctoproject.org/meta-yocto whinlatter ${BRANCH}/layers/meta-yocto
     - name: Clone meta-openembedded
       run: |
+        mkdir -p "${BRANCH}/layers"
         if [ ! -d ${BRANCH}/layers/meta-openembedded ]; then
           git clone https://github.com/openembedded/meta-openembedded.git -b ${BRANCH} ${BRANCH}/layers/meta-openembedded
         else

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -30,4 +30,4 @@ INSANE_SKIP:msbuild-dev += "buildpaths"
 INSANE_SKIP:python3-clr-loader += "buildpaths"
 INSANE_SKIP:python3-pythonnet += "buildpaths"
 
-LAYERSERIES_COMPAT_mono = "styhead"
+LAYERSERIES_COMPAT_mono = "whinlatter"

--- a/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
+++ b/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
@@ -11,8 +11,6 @@ SRCREV = "9a72bb67fff7e4845b7bb430a608282668c3e4da"
 SRC_URI = "git://github.com/mono/gtk-sharp.git;protocol=https;branch=master \
            file://0001-fixup-gmcs-to-mcs.patch"
 
-S = "${UNPACKDIR}/git"
-
 do_configure:prepend() {
   export PROFILER_CFLAGS="-D_REENTRANT -I${STAGING_DIR_TARGET}/usr/include/glib-2.0 -I${STAGING_DIR_TARGET}/usr/lib/glib-2.0 -I${STAGING_DIR_TARGET}/usr/lib/glib-2.0/include -I${STAGING_DIR_TARGET}/usr/include/mono-2.0"
 }

--- a/recipes-mono/libgdiplus/libgdiplus-common.inc
+++ b/recipes-mono/libgdiplus/libgdiplus-common.inc
@@ -11,8 +11,6 @@ SRC_URI = " \
 	gitsm://github.com/mono/libgdiplus.git;protocol=https;branch=${BRANCH} \
 "
 
-S = "${UNPACKDIR}/git"
-
 inherit autotools pkgconfig
 
 FILES:${PN} += "${libdir}/libgdiplus.so"

--- a/recipes-mono/mono-addins/mono-addins-xbuild.inc
+++ b/recipes-mono/mono-addins/mono-addins-xbuild.inc
@@ -13,8 +13,6 @@ SRCBRANCH = "master"
 
 SRC_URI = "git://github.com/mono/mono-addins.git;protocol=https;branch=${SRCBRANCH}"
 
-S = "${UNPACKDIR}/git"
-
 do_configure() {
 }
 

--- a/recipes-mono/mono-addins/mono-addins.inc
+++ b/recipes-mono/mono-addins/mono-addins.inc
@@ -14,7 +14,5 @@ SRCBRANCH = "master"
 SRC_URI = "git://github.com/mono/mono-addins.git;protocol=https;branch=${SRCBRANCH} \
 	   file://0001-configure-mcs.patch"
 
-S = "${UNPACKDIR}/git"
-
 inherit autotools-brokensep pkgconfig
 inherit mono

--- a/recipes-mono/mono-upnp/mono-upnp.inc
+++ b/recipes-mono/mono-upnp/mono-upnp.inc
@@ -16,8 +16,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}-${PV}:"
 SRC_URI = "git://github.com/mono/mono-upnp.git;protocol=https;branch=${SRCBRANCH} \
 "
 
-S = "${UNPACKDIR}/git"
-
 inherit autotools-brokensep pkgconfig
 
 do_configure () {

--- a/recipes-mono/mono-xsp/mono-xsp_git.bb
+++ b/recipes-mono/mono-xsp/mono-xsp_git.bb
@@ -3,5 +3,3 @@ require mono-xsp-3.x.inc
 SRCREV= "e272a2c006211b6b03be2ef5bbb9e3f8fefd0768"
 SRC_URI = "git://github.com/mono/xsp.git;branch=main;protocol=https \
 	  "
-
-S = "${UNPACKDIR}/git"

--- a/recipes-mono/mono/mono-4.xx.inc
+++ b/recipes-mono/mono/mono-4.xx.inc
@@ -94,4 +94,4 @@ FILES:${PN}-staticdev			+= " ${libdir}/*.a"
 RDEPENDS:${PN}-dev =+ "bash"
 
 # Workaround for observed race in `make install`
-PARALLEL_MAKEINST=""
+PARALLEL_MAKEINST = ""

--- a/recipes-mono/mono/mono-5.xx.inc
+++ b/recipes-mono/mono/mono-5.xx.inc
@@ -106,7 +106,7 @@ RDEPENDS:${PN}-dev =+ "bash"
 RDEPENDS:${PN}-libs =+ "zlib"
 
 # Workaround for observed race in `make install`
-PARALLEL_MAKEINST=""
+PARALLEL_MAKEINST = ""
 
 # Otherwise the full path to bash is written to the first line of doltlibtool script
 # which causes build failures with deeply nested build directories

--- a/recipes-mono/mono/mono-6.12.0.206.inc
+++ b/recipes-mono/mono/mono-6.12.0.206.inc
@@ -1,3 +1,1 @@
-S = "${UNPACKDIR}/git"
-
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-6.12.0.206.inc
+++ b/recipes-mono/mono/mono-6.12.0.206.inc
@@ -1,1 +1,3 @@
+S = "${UNPACKDIR}/${BP}"
+
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-6.12.0.206/0001-Btls-too-old-cmake-version.patch
+++ b/recipes-mono/mono/mono-6.12.0.206/0001-Btls-too-old-cmake-version.patch
@@ -1,0 +1,30 @@
+From ba1b408ff40e3770785a7774f2bf88758a33a49d Mon Sep 17 00:00:00 2001
+From: Marian Cingel <cingel.marian@gmail.com>
+Date: Mon, 18 May 2026 20:12:28 +0000
+Subject: [PATCH] Btls - too old cmake version
+
+Upstream-Status: Pending
+---
+ mono/btls/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/mono/btls/CMakeLists.txt b/mono/btls/CMakeLists.txt
+index 992f41e4c7f..012b6d12669 100644
+--- a/mono/btls/CMakeLists.txt
++++ b/mono/btls/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 2.8.10)
++cmake_minimum_required (VERSION 4.0)
+ 
+ project (mono-btls)
+ 
+@@ -129,4 +129,4 @@ endif ()
+ 
+ if (CYGWIN)
+ 	target_link_libraries (mono-btls-shared wsock32 ws2_32)
+-endif ()
+\ No newline at end of file
++endif ()
+-- 
+2.53.0
+

--- a/recipes-mono/mono/mono-6.12.0.206/boringssl-cmake-version.diff
+++ b/recipes-mono/mono/mono-6.12.0.206/boringssl-cmake-version.diff
@@ -1,0 +1,10 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
+--- mono-6.12.0.206/external/boringssl/CMakeLists.txt.orig	2026-05-18 22:51:14.239405666 +0000
++++ mono-6.12.0.206/external/boringssl/CMakeLists.txt	2026-05-18 22:51:21.634960290 +0000
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 2.8.10)
++cmake_minimum_required (VERSION 4.0)
+ 
+ # Defer enabling C and CXX languages.
+ project (BoringSSL NONE)

--- a/recipes-mono/mono/mono-6.xx.inc
+++ b/recipes-mono/mono/mono-6.xx.inc
@@ -127,7 +127,7 @@ INSANE_SKIP:${PN}-xbuild		= "file-rdeps"
 INSANE_SKIP:${PN}-configuration-crypto	= "file-rdeps"
 
 # Workaround for observed race in `make install`
-PARALLEL_MAKEINST=""
+PARALLEL_MAKEINST = ""
 
 # Otherwise the full path to bash is written to the first line of doltlibtool script
 # which causes build failures with deeply nested build directories

--- a/recipes-mono/mono/mono-git.inc
+++ b/recipes-mono/mono/mono-git.inc
@@ -83,4 +83,4 @@ FILES:${PN}-profiler			+= " ${datadir}/mono-2.0/mono/profiler/*"
 RDEPENDS:${PN} =+ "bash" 
 
 # Workaround for observed race in `make install`
-PARALLEL_MAKEINST=""
+PARALLEL_MAKEINST = ""

--- a/recipes-mono/mono/mono-git.inc
+++ b/recipes-mono/mono/mono-git.inc
@@ -23,6 +23,8 @@ SRC_URI = "git://github.com/mono/mono.git;branch=${SRCBRANCH}\
 #	   file://0001-reintroduce-gmcs.patch \
 #
 
+S = "${UNPACKDIR}/${BP}"
+
 FILESPATH =. "${FILE_DIRNAME}/mono-4.xx:"
 FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"
 

--- a/recipes-mono/mono/mono-git.inc
+++ b/recipes-mono/mono/mono-git.inc
@@ -23,8 +23,6 @@ SRC_URI = "git://github.com/mono/mono.git;branch=${SRCBRANCH}\
 #	   file://0001-reintroduce-gmcs.patch \
 #
 
-S = "${UNPACKDIR}/git"
-
 FILESPATH =. "${FILE_DIRNAME}/mono-4.xx:"
 FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"
 

--- a/recipes-mono/mono/mono-native_6.12.0.206.bb
+++ b/recipes-mono/mono/mono-native_6.12.0.206.bb
@@ -12,6 +12,8 @@ SRC_URI = "gitsm://github.com/mono/mono.git;protocol=https;branch=2020-02 \
            file://shm_open-test-crosscompile.diff \
            file://disable-mmap-MAP_32BIT-support.patch \
            file://0001-Allow-passing-external-mapfile-C-build-options.patch \
+           file://0001-Btls-too-old-cmake-version.patch \
+           file://boringssl-cmake-version.diff \
 "
 
 addtask fixup_config after do_patch before do_configure

--- a/recipes-mono/mono/mono_6.12.0.206.bb
+++ b/recipes-mono/mono/mono_6.12.0.206.bb
@@ -12,6 +12,8 @@ SRC_URI = "gitsm://github.com/mono/mono.git;protocol=https;branch=2020-02 \
            file://disable-mmap-MAP_32BIT-support.patch \
            file://0001-Allow-passing-external-mapfile-C-build-options.patch \
            file://0001-Add-libusb-1.0-mapping.patch \
+           file://0001-Btls-too-old-cmake-version.patch \
+           file://boringssl-cmake-version.diff \
 "
 
 

--- a/recipes-mono/msbuild/msbuild_16.10.1.bb
+++ b/recipes-mono/msbuild/msbuild_16.10.1.bb
@@ -21,8 +21,6 @@ SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git;branch=main;protoco
            file://0001-Copy-hostfxr.patch \
            "
 
-S = "${UNPACKDIR}/git"
-
 do_configure () {
     sed "s|%libhostfxr%|${STAGING_DIR_TARGET}${libdir}/libhostfxr.so|g" -i ${S}/eng/cibuild_bootstrapped_msbuild.sh
 

--- a/recipes-mono/nuget/nuget.inc
+++ b/recipes-mono/nuget/nuget.inc
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://Apache-LICENSE-2.0.txt;md5=3b83ef96387f14655fc854ddc3
 HOMEPAGE = "http://nuget.org/"
 
 # This package ships Mono EXE and a shell script
-PACKAGE_ARCH="all"
+PACKAGE_ARCH = "all"
 
 # Fully updated Fedora 33 and 34 say that dist.nuget.org cert is untrusted
 BB_CHECK_SSL_CERTS = "0"

--- a/recipes-mono/taglib-sharp/taglib-sharp.inc
+++ b/recipes-mono/taglib-sharp/taglib-sharp.inc
@@ -10,8 +10,6 @@ DEPENDS = "mono"
 
 SRC_URI = "git://github.com/mono/taglib-sharp.git;protocol=https;branch=${SRCBRANCH}"
 
-S = "${UNPACKDIR}/git"
-
 inherit autotools-brokensep pkgconfig
 
 EXTRA_OECONF = " --disable-docs"


### PR DESCRIPTION
## Summary

Migrate meta-mono to support Yocto 5.3 (whinlatter). The poky repository no longer maintains release branches from whinlatter onwards, requiring a new CI setup approach.

- **CI: replace poky clone with individual repo clones** -- bitbake (branch 2.16), openembedded-core (whinlatter), meta-yocto (whinlatter), with updated `oe-init-build-env` and `TEMPLATECONF` paths
- **Recipe whitespace fixes** -- add spaces around `=` in `PARALLEL_MAKEINST` and `PACKAGE_ARCH` assignments (5 files) to suppress whinlatter warnings
- **`LAYERSERIES_COMPAT`** updated from `styhead` to `whinlatter`

## References

- Migration guide: https://docs.yoctoproject.org/dev/migration-guides/migration-5.3.html
- Tracking issue: #275

## Test plan

- [ ] CI builds pass for whinlatter x86-64 and arm64
- [ ] dotnet 10.0.100, 8.0.406, 6.0.428 all build successfully
- [ ] mono 6.12.0.206 builds successfully
- [ ] Test image boots and passes testimage


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI now fetches and initializes Yocto from multiple upstream repos (instead of `poky`), so failures are most likely due to branch/path mismatches or layer ordering; recipe changes are formatting-only but can affect parsing under newer BitBake.
> 
> **Overview**
> Updates the project to target Yocto 5.3 `whinlatter` by switching `LAYERSERIES_COMPAT_mono` and adjusting CI to build/test against the `whinlatter` branch.
> 
> The GitHub Actions workflow stops cloning `poky` and instead clones `bitbake`, `openembedded-core`, and `meta-yocto` into a `layers/` layout, updates `TEMPLATECONF`/`oe-init-build-env` paths accordingly, and limits the build matrix to `whinlatter` on `x86-64` and `arm64`.
> 
> Separately, recipe metadata is normalized for `whinlatter` parsing (whitespace around `=`), including `PARALLEL_MAKEINST` in Mono include files and `PACKAGE_ARCH` in `nuget.inc`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 863f4db0d3020f60d4985e754c8705066bf55b67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->