### PR TITLE
Update layer config to support wrynose release (6.0)

### DIFF
--- a/classes/mono.bbclass
+++ b/classes/mono.bbclass
@@ -31,12 +31,12 @@ FILES:${PN}-doc:append = " \
   ${libdir}/monodoc/* \
 "
 
-export MONO_CFG_DIR="${STAGING_ETCDIR_NATIVE}"
+export MONO_CFG_DIR = "${STAGING_ETCDIR_NATIVE}"
 
 # NuGet uses $HOME/.nuget/packages to store packages by default
 # but we should not use anything outside the build root of packages.
-export NUGET_PACKAGES="${UNPACKDIR}/mono-nuget-packages"
-export NUGET_HTTP_CACHE_PATH="${UNPACKDIR}/mono-nuget-http-cache"
+export NUGET_PACKAGES = "${UNPACKDIR}/mono-nuget-packages"
+export NUGET_HTTP_CACHE_PATH = "${UNPACKDIR}/mono-nuget-http-cache"
 
 do_configure:prepend() {
 	mkdir -p ${NUGET_PACKAGES} ${NUGET_HTTP_CACHE_PATH}

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -33,4 +33,4 @@ INSANE_SKIP:msbuild-dev += "buildpaths"
 INSANE_SKIP:python3-clr-loader += "buildpaths"
 INSANE_SKIP:python3-pythonnet += "buildpaths"
 
-LAYERSERIES_COMPAT_mono = "styhead"
+LAYERSERIES_COMPAT_mono = "wrynose"

--- a/recipes-mono/dotnet-helloworld/dotnet-helloworld_1.0.bb
+++ b/recipes-mono/dotnet-helloworld/dotnet-helloworld_1.0.bb
@@ -19,13 +19,13 @@ COMPATIBLE_HOST ?= "(x86_64|aarch64|arm).*-linux"
 
 # NuGet MigrationRunner in .NET 6 hardcodes $HOME for migrations dir.
 # Override HOME so it's always writable (CI containers often have read-only HOME).
-export HOME="${WORKDIR}/dotnet-home"
-export DOTNET_CLI_HOME="${WORKDIR}/dotnet-home"
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE="true"
-export DOTNET_CLI_TELEMETRY_OPTOUT="1"
-export DOTNET_NOLOGO="1"
-export NUGET_PACKAGES="${UNPACKDIR}/nuget-packages"
-export NUGET_HTTP_CACHE_PATH="${UNPACKDIR}/nuget-http-cache"
+export HOME = "${WORKDIR}/dotnet-home"
+export DOTNET_CLI_HOME = "${WORKDIR}/dotnet-home"
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE = "true"
+export DOTNET_CLI_TELEMETRY_OPTOUT = "1"
+export DOTNET_NOLOGO = "1"
+export NUGET_PACKAGES = "${UNPACKDIR}/nuget-packages"
+export NUGET_HTTP_CACHE_PATH = "${UNPACKDIR}/nuget-http-cache"
 
 SRC_ARCH:aarch64 = "arm64"
 SRC_ARCH:arm = "arm"

--- a/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
+++ b/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
@@ -11,7 +11,6 @@ SRCREV = "9a72bb67fff7e4845b7bb430a608282668c3e4da"
 SRC_URI = "git://github.com/mono/gtk-sharp.git;protocol=https;branch=master \
            file://0001-fixup-gmcs-to-mcs.patch"
 
-S = "${UNPACKDIR}/git"
 
 do_configure:prepend() {
   export PROFILER_CFLAGS="-D_REENTRANT -I${STAGING_DIR_TARGET}/usr/include/glib-2.0 -I${STAGING_DIR_TARGET}/usr/lib/glib-2.0 -I${STAGING_DIR_TARGET}/usr/lib/glib-2.0/include -I${STAGING_DIR_TARGET}/usr/include/mono-2.0"

--- a/recipes-mono/libgdiplus/libgdiplus-common.inc
+++ b/recipes-mono/libgdiplus/libgdiplus-common.inc
@@ -11,7 +11,6 @@ SRC_URI = " \
 	gitsm://github.com/mono/libgdiplus.git;protocol=https;branch=${BRANCH} \
 "
 
-S = "${UNPACKDIR}/git"
 
 inherit autotools pkgconfig
 

--- a/recipes-mono/mono-addins/mono-addins-xbuild.inc
+++ b/recipes-mono/mono-addins/mono-addins-xbuild.inc
@@ -13,7 +13,6 @@ SRCBRANCH = "master"
 
 SRC_URI = "git://github.com/mono/mono-addins.git;protocol=https;branch=${SRCBRANCH}"
 
-S = "${UNPACKDIR}/git"
 
 do_configure() {
 }

--- a/recipes-mono/mono-addins/mono-addins.inc
+++ b/recipes-mono/mono-addins/mono-addins.inc
@@ -14,7 +14,6 @@ SRCBRANCH = "master"
 SRC_URI = "git://github.com/mono/mono-addins.git;protocol=https;branch=${SRCBRANCH} \
 	   file://0001-configure-mcs.patch"
 
-S = "${UNPACKDIR}/git"
 
 inherit autotools-brokensep pkgconfig
 inherit mono

--- a/recipes-mono/mono-helloworld/mono-helloworld_git.bb.disabled
+++ b/recipes-mono/mono-helloworld/mono-helloworld_git.bb.disabled
@@ -2,4 +2,3 @@ require mono-helloworld.inc
 
 SRCREV = "${AUTOREV}"
 SRC_URI =  "git://github.com/DynamicDevices/mono-helloworld.git" 
-S = "${UNPACKDIR}/git"

--- a/recipes-mono/mono-upnp/mono-upnp.inc
+++ b/recipes-mono/mono-upnp/mono-upnp.inc
@@ -16,7 +16,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}-${PV}:"
 SRC_URI = "git://github.com/mono/mono-upnp.git;protocol=https;branch=${SRCBRANCH} \
 "
 
-S = "${UNPACKDIR}/git"
 
 inherit autotools-brokensep pkgconfig
 

--- a/recipes-mono/mono-xsp/mono-xsp_git.bb
+++ b/recipes-mono/mono-xsp/mono-xsp_git.bb
@@ -1,6 +1,6 @@
 require mono-xsp-3.x.inc
 
-SRCREV= "e272a2c006211b6b03be2ef5bbb9e3f8fefd0768"
+SRCREV = "e272a2c006211b6b03be2ef5bbb9e3f8fefd0768"
 SRC_URI = "git://github.com/mono/xsp.git;branch=main;protocol=https \
 	  "
 

--- a/recipes-mono/mono-xsp/mono-xsp_git.bb
+++ b/recipes-mono/mono-xsp/mono-xsp_git.bb
@@ -4,4 +4,3 @@ SRCREV= "e272a2c006211b6b03be2ef5bbb9e3f8fefd0768"
 SRC_URI = "git://github.com/mono/xsp.git;branch=main;protocol=https \
 	  "
 
-S = "${UNPACKDIR}/git"

--- a/recipes-mono/mono/mono-4.xx.inc
+++ b/recipes-mono/mono/mono-4.xx.inc
@@ -94,4 +94,4 @@ FILES:${PN}-staticdev			+= " ${libdir}/*.a"
 RDEPENDS:${PN}-dev =+ "bash"
 
 # Workaround for observed race in `make install`
-PARALLEL_MAKEINST=""
+PARALLEL_MAKEINST = ""

--- a/recipes-mono/mono/mono-4.xx.inc
+++ b/recipes-mono/mono/mono-4.xx.inc
@@ -19,19 +19,6 @@ SRC_URI = "http://download.mono-project.com/sources/mono/mono-${PV}.tar.bz2 \
 #	   file://0001-reintroduce-gmcs.patch \
 #
 
-def mono_workspace_version (d):
-    pvsplit = d.getVar('PV').split('.')
-    if len(pvsplit) == 3:
-        return pvsplit[0] + '.' + pvsplit[1] + '.' + pvsplit[2]
-    elif len(pvsplit) == 2:
-        return pvsplit[0] + '.' + pvsplit[1]
-    elif len(pvsplit) == 1:
-        return pvsplit[0]
-    else:
-        return 0
-
-S = "${UNPACKDIR}/mono-${@mono_workspace_version(d)}"
-
 FILESPATH =. "${FILE_DIRNAME}/mono-4.xx:"
 FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"
 

--- a/recipes-mono/mono/mono-5.xx.inc
+++ b/recipes-mono/mono/mono-5.xx.inc
@@ -106,7 +106,7 @@ RDEPENDS:${PN}-dev =+ "bash"
 RDEPENDS:${PN}-libs =+ "zlib"
 
 # Workaround for observed race in `make install`
-PARALLEL_MAKEINST=""
+PARALLEL_MAKEINST = ""
 
 # Otherwise the full path to bash is written to the first line of doltlibtool script
 # which causes build failures with deeply nested build directories

--- a/recipes-mono/mono/mono-5.xx.inc
+++ b/recipes-mono/mono/mono-5.xx.inc
@@ -19,19 +19,6 @@ SRC_URI = "http://download.mono-project.com/sources/mono/mono-${PV}.tar.bz2 \
 #	   file://0001-reintroduce-gmcs.patch \
 #
 
-def mono_workspace_version (d):
-    pvsplit = d.getVar('PV',d,1).split('.')
-    if len(pvsplit) == 3:
-        return pvsplit[0] + '.' + pvsplit[1] + '.' + pvsplit[2]
-    elif len(pvsplit) == 2:
-        return pvsplit[0] + '.' + pvsplit[1]
-    elif len(pvsplit) == 1:
-        return pvsplit[0]
-    else:
-        return 0
-
-S = "${UNPACKDIR}/mono-${@mono_workspace_version(d)}"
-
 FILESPATH =. "${FILE_DIRNAME}/mono-5.xx:"
 FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"
 

--- a/recipes-mono/mono/mono-6.12.0.206.inc
+++ b/recipes-mono/mono/mono-6.12.0.206.inc
@@ -1,3 +1,2 @@
-S = "${UNPACKDIR}/git"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-6.xx.inc
+++ b/recipes-mono/mono/mono-6.xx.inc
@@ -127,7 +127,7 @@ INSANE_SKIP:${PN}-xbuild		= "file-rdeps"
 INSANE_SKIP:${PN}-configuration-crypto	= "file-rdeps"
 
 # Workaround for observed race in `make install`
-PARALLEL_MAKEINST=""
+PARALLEL_MAKEINST = ""
 
 # Otherwise the full path to bash is written to the first line of doltlibtool script
 # which causes build failures with deeply nested build directories

--- a/recipes-mono/mono/mono-6.xx.inc
+++ b/recipes-mono/mono/mono-6.xx.inc
@@ -18,12 +18,6 @@ SRC_URI = "http://download.mono-project.com/sources/mono/mono-${PV}.tar.xz \
 #	   file://0001-reintroduce-gmcs.patch \
 #
 
-def mono_workspace_version (d):
-    pvsplit = d.getVar('PV',d,1).split('.')
-    return pvsplit[0] + '.' + pvsplit[1] + '.' + pvsplit[2]
-
-S = "${UNPACKDIR}/mono-${@mono_workspace_version(d)}"
-
 FILESPATH =. "${FILE_DIRNAME}/mono-6.xx:"
 FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"
 

--- a/recipes-mono/mono/mono-git.inc
+++ b/recipes-mono/mono/mono-git.inc
@@ -23,7 +23,6 @@ SRC_URI = "git://github.com/mono/mono.git;branch=${SRCBRANCH}\
 #	   file://0001-reintroduce-gmcs.patch \
 #
 
-S = "${UNPACKDIR}/git"
 
 FILESPATH =. "${FILE_DIRNAME}/mono-4.xx:"
 FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"

--- a/recipes-mono/mono/mono-git.inc
+++ b/recipes-mono/mono/mono-git.inc
@@ -82,4 +82,4 @@ FILES:${PN}-profiler			+= " ${datadir}/mono-2.0/mono/profiler/*"
 RDEPENDS:${PN} =+ "bash" 
 
 # Workaround for observed race in `make install`
-PARALLEL_MAKEINST=""
+PARALLEL_MAKEINST = ""

--- a/recipes-mono/msbuild/msbuild_16.10.1.bb
+++ b/recipes-mono/msbuild/msbuild_16.10.1.bb
@@ -21,7 +21,6 @@ SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git;branch=main;protoco
            file://0001-Copy-hostfxr.patch \
            "
 
-S = "${UNPACKDIR}/git"
 
 do_configure () {
     sed "s|%libhostfxr%|${STAGING_DIR_TARGET}${libdir}/libhostfxr.so|g" -i ${S}/eng/cibuild_bootstrapped_msbuild.sh

--- a/recipes-mono/msbuild/msbuild_16.10.1.bb
+++ b/recipes-mono/msbuild/msbuild_16.10.1.bb
@@ -34,8 +34,8 @@ do_configure () {
     sed "s|\$1/lib|${libdir}|g" -i ${S}/mono/build/gen_msbuild_wrapper.sh
 }
 
-export DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR="${STAGING_DATADIR_NATIVE}/dotnet"
-export CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt"
+export DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR = "${STAGING_DATADIR_NATIVE}/dotnet"
+export CURL_CA_BUNDLE = "${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt"
 
 do_compile[network] = "1"
 

--- a/recipes-mono/nuget/nuget.inc
+++ b/recipes-mono/nuget/nuget.inc
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://Apache-LICENSE-2.0.txt;md5=3b83ef96387f14655fc854ddc3
 HOMEPAGE = "http://nuget.org/"
 
 # This package ships Mono EXE and a shell script
-PACKAGE_ARCH="all"
+PACKAGE_ARCH = "all"
 
 # Fully updated Fedora 33 and 34 say that dist.nuget.org cert is untrusted
 BB_CHECK_SSL_CERTS = "0"

--- a/recipes-mono/taglib-sharp/taglib-sharp.inc
+++ b/recipes-mono/taglib-sharp/taglib-sharp.inc
@@ -10,7 +10,6 @@ DEPENDS = "mono"
 
 SRC_URI = "git://github.com/mono/taglib-sharp.git;protocol=https;branch=${SRCBRANCH}"
 
-S = "${UNPACKDIR}/git"
 
 inherit autotools-brokensep pkgconfig
 

--- a/recipes-python/python3-clr-loader/python3-clr-loader.bb
+++ b/recipes-python/python3-clr-loader/python3-clr-loader.bb
@@ -29,26 +29,26 @@ RDEPENDS:${PN} += " \
 # NuGet uses $HOME/.nuget/packages to store packages by default
 # but we should not use anything outside the build root of packages.
 # Use a separated folder for nuget downloads and cache in UNPACKDIR.
-export NUGET_PACKAGES="${UNPACKDIR}/nuget-packages"
-export NUGET_HTTP_CACHE_PATH="${UNPACKDIR}/nuget-http-cache"
+export NUGET_PACKAGES = "${UNPACKDIR}/nuget-packages"
+export NUGET_HTTP_CACHE_PATH = "${UNPACKDIR}/nuget-http-cache"
 
 # NuGet MigrationRunner.Run() in .NET 6 runs BEFORE the skip-first-time
 # check, and hardcodes $HOME/.local/share/NuGet/Migrations.  In CI
 # containers $HOME is often read-only.  Override HOME to a writable path
 # so NuGet, dotnet CLI, and any other $HOME consumer all get a writable dir.
-export HOME="${WORKDIR}/dotnet-home"
-export DOTNET_CLI_HOME="${WORKDIR}/dotnet-home"
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE="true"
-export DOTNET_CLI_TELEMETRY_OPTOUT="1"
-export DOTNET_NOLOGO="1"
+export HOME = "${WORKDIR}/dotnet-home"
+export DOTNET_CLI_HOME = "${WORKDIR}/dotnet-home"
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE = "true"
+export DOTNET_CLI_TELEMETRY_OPTOUT = "1"
+export DOTNET_NOLOGO = "1"
 
 # Workaround for dotnet restore issue, define custom proxy in a .bbappend
 # and/or in layer.conf or local.conf if dotnet restore was failed.
 # Override DOTNET_HTTP_PROXY and DOTNET_HTTPS_PROXY in layer.conf or local.conf if needed
 DOTNET_HTTP_PROXY ?= ""
 DOTNET_HTTPS_PROXY ?= ""
-export http_proxy="${DOTNET_HTTP_PROXY}"
-export https_proxy="${DOTNET_HTTPS_PROXY}"
+export http_proxy = "${DOTNET_HTTP_PROXY}"
+export https_proxy = "${DOTNET_HTTPS_PROXY}"
 
 do_configure:prepend() {
     if ! grep -Fq __version__ ${S}/clr_loader/__init__.py

--- a/recipes-python/python3-pythonnet/python3-pythonnet.bb
+++ b/recipes-python/python3-pythonnet/python3-pythonnet.bb
@@ -38,16 +38,16 @@ RDEPENDS:${PN} += " \
 # NuGet uses $HOME/.nuget/packages to store packages by default
 # but we should not use anything outside the build root of packages.
 # Use a separated folder for nuget downloads and cache in UNPACKDIR.
-export NUGET_PACKAGES="${UNPACKDIR}/nuget-packages"
-export NUGET_HTTP_CACHE_PATH="${UNPACKDIR}/nuget-http-cache"
+export NUGET_PACKAGES = "${UNPACKDIR}/nuget-packages"
+export NUGET_HTTP_CACHE_PATH = "${UNPACKDIR}/nuget-http-cache"
 
 # Workaround for dotnet restore issue, define custom proxy in a .bbappend
 # and/or in layer.conf or local.conf if dotnet restore was failed.
 # Override DOTNET_HTTP_PROXY and DOTNET_HTTPS_PROXY in layer.conf or local.conf if needed
 DOTNET_HTTP_PROXY ?= ""
 DOTNET_HTTPS_PROXY ?= ""
-export http_proxy="${DOTNET_HTTP_PROXY}"
-export https_proxy="${DOTNET_HTTPS_PROXY}"
+export http_proxy = "${DOTNET_HTTP_PROXY}"
+export https_proxy = "${DOTNET_HTTPS_PROXY}"
 
 do_configure:prepend() {
     if ! grep -Fq __version__ ${S}/pythonnet/__init__.py


### PR DESCRIPTION
This commit only updates LAYERSERIES_COMPAT further changes to run tests in the CI are required.

Only used to build include dotnet in our image. Other features not touched..

---

As poky does not exist on wrynose I think the CI needs to be changed to use bitbake-setup to run test jobs in the CI. I'm happy to help implementing this if you are also working on this please reach out. If not I'll try to update this PR or create another one (but need to build our application first).