### PR TITLE
recipes: remove S = ${UNPACKDIR}/git for Whinlatter compliance

### DIFF
--- a/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
+++ b/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
@@ -11,8 +11,6 @@ SRCREV = "9a72bb67fff7e4845b7bb430a608282668c3e4da"
 SRC_URI = "git://github.com/mono/gtk-sharp.git;protocol=https;branch=master \
            file://0001-fixup-gmcs-to-mcs.patch"
 
-S = "${UNPACKDIR}/git"
-
 do_configure:prepend() {
   export PROFILER_CFLAGS="-D_REENTRANT -I${STAGING_DIR_TARGET}/usr/include/glib-2.0 -I${STAGING_DIR_TARGET}/usr/lib/glib-2.0 -I${STAGING_DIR_TARGET}/usr/lib/glib-2.0/include -I${STAGING_DIR_TARGET}/usr/include/mono-2.0"
 }

--- a/recipes-mono/libgdiplus/libgdiplus-common.inc
+++ b/recipes-mono/libgdiplus/libgdiplus-common.inc
@@ -11,8 +11,6 @@ SRC_URI = " \
 	gitsm://github.com/mono/libgdiplus.git;protocol=https;branch=${BRANCH} \
 "
 
-S = "${UNPACKDIR}/git"
-
 inherit autotools pkgconfig
 
 FILES:${PN} += "${libdir}/libgdiplus.so"

--- a/recipes-mono/mono-addins/mono-addins-xbuild.inc
+++ b/recipes-mono/mono-addins/mono-addins-xbuild.inc
@@ -13,8 +13,6 @@ SRCBRANCH = "master"
 
 SRC_URI = "git://github.com/mono/mono-addins.git;protocol=https;branch=${SRCBRANCH}"
 
-S = "${UNPACKDIR}/git"
-
 do_configure() {
 }
 

--- a/recipes-mono/mono-addins/mono-addins.inc
+++ b/recipes-mono/mono-addins/mono-addins.inc
@@ -14,7 +14,5 @@ SRCBRANCH = "master"
 SRC_URI = "git://github.com/mono/mono-addins.git;protocol=https;branch=${SRCBRANCH} \
 	   file://0001-configure-mcs.patch"
 
-S = "${UNPACKDIR}/git"
-
 inherit autotools-brokensep pkgconfig
 inherit mono

--- a/recipes-mono/mono-upnp/mono-upnp.inc
+++ b/recipes-mono/mono-upnp/mono-upnp.inc
@@ -16,8 +16,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}-${PV}:"
 SRC_URI = "git://github.com/mono/mono-upnp.git;protocol=https;branch=${SRCBRANCH} \
 "
 
-S = "${UNPACKDIR}/git"
-
 inherit autotools-brokensep pkgconfig
 
 do_configure () {

--- a/recipes-mono/mono-xsp/mono-xsp_git.bb
+++ b/recipes-mono/mono-xsp/mono-xsp_git.bb
@@ -3,5 +3,3 @@ require mono-xsp-3.x.inc
 SRCREV= "e272a2c006211b6b03be2ef5bbb9e3f8fefd0768"
 SRC_URI = "git://github.com/mono/xsp.git;branch=main;protocol=https \
 	  "
-
-S = "${UNPACKDIR}/git"

--- a/recipes-mono/mono/mono-6.12.0.206.inc
+++ b/recipes-mono/mono/mono-6.12.0.206.inc
@@ -1,3 +1,1 @@
-S = "${UNPACKDIR}/git"
-
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-git.inc
+++ b/recipes-mono/mono/mono-git.inc
@@ -23,8 +23,6 @@ SRC_URI = "git://github.com/mono/mono.git;branch=${SRCBRANCH}\
 #	   file://0001-reintroduce-gmcs.patch \
 #
 
-S = "${UNPACKDIR}/git"
-
 FILESPATH =. "${FILE_DIRNAME}/mono-4.xx:"
 FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"
 

--- a/recipes-mono/msbuild/msbuild_16.10.1.bb
+++ b/recipes-mono/msbuild/msbuild_16.10.1.bb
@@ -21,8 +21,6 @@ SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git;branch=main;protoco
            file://0001-Copy-hostfxr.patch \
            "
 
-S = "${UNPACKDIR}/git"
-
 do_configure () {
     sed "s|%libhostfxr%|${STAGING_DIR_TARGET}${libdir}/libhostfxr.so|g" -i ${S}/eng/cibuild_bootstrapped_msbuild.sh
 

--- a/recipes-mono/taglib-sharp/taglib-sharp.inc
+++ b/recipes-mono/taglib-sharp/taglib-sharp.inc
@@ -10,8 +10,6 @@ DEPENDS = "mono"
 
 SRC_URI = "git://github.com/mono/taglib-sharp.git;protocol=https;branch=${SRCBRANCH}"
 
-S = "${UNPACKDIR}/git"
-
 inherit autotools-brokensep pkgconfig
 
 EXTRA_OECONF = " --disable-docs"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the CI build failure in [run 28430587738](https://github.com/DynamicDevices/meta-mono/actions/runs/28430587738/job/84244052026).

## Problem

The whinlatter build failed during `mono-native-6.12.0.206:do_unpack` with:

```
ERROR: Recipes that set S = "${WORKDIR}/git" or S = "${UNPACKDIR}/git" should remove that assignment, as S set by bitbake.conf in oe-core now works.
```

Yocto 5.3 (whinlatter) changed the git fetcher to unpack into `BB_GIT_DEFAULT_DESTSUFFIX` (set to `${BP}` in oe-core), which matches the default `S` from `bitbake.conf`. Explicit `S = "${UNPACKDIR}/git"` assignments are now rejected.

## Fix

Remove all `S = "${UNPACKDIR}/git"` lines from git-based recipes across the layer (10 files):

- `recipes-mono/mono/mono-6.12.0.206.inc` (the immediate CI failure)
- `recipes-mono/mono/mono-git.inc`
- `recipes-mono/msbuild/msbuild_16.10.1.bb`
- `recipes-mono/taglib-sharp/taglib-sharp.inc`
- `recipes-mono/mono-xsp/mono-xsp_git.bb`
- `recipes-mono/mono-addins/mono-addins-xbuild.inc`
- `recipes-mono/mono-addins/mono-addins.inc`
- `recipes-mono/mono-upnp/mono-upnp.inc`
- `recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb`
- `recipes-mono/libgdiplus/libgdiplus-common.inc`

Per the [Yocto 5.3 migration guide](https://docs.yoctoproject.org/5.3/migration-guides/migration-5.3.html), these assignments should simply be deleted — no replacement is needed for recipes where the source root is the git checkout itself.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cee2e99-b89d-48d4-a90f-8d7d352bde70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cee2e99-b89d-48d4-a90f-8d7d352bde70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

