### PR TITLE
wrynose: recipe fixes + CI HTTPS clone (fix #282)

### DIFF
--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - master
-      - feature/yocto-layer-compliance
   pull_request:
     branches:
       - master
-      - feature/yocto-layer-compliance
     paths-ignore:
       - "**.md"
 jobs:
@@ -23,11 +21,11 @@ jobs:
       matrix:
         dotnet_version: [10.0.100, 8.0.406, 6.0.428]
         mono_version: [6.12.0.206]
-        branch: [styhead]
+        branch: [whinlatter]
         arch: [x86-64, arm, arm64]
         exclude:
-          # styhead GCC build broken for ARM32 - see README "Removal of support for ARM32" and discussions/234
-          - branch: styhead
+          # GCC build broken for ARM32 - see README and discussions/234
+          - branch: whinlatter
             arch: arm
     env:
       name: build-and-test

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - whinlatter
   pull_request:
     branches:
       - master
+      - whinlatter
     paths-ignore:
       - "**.md"
 jobs:

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -91,10 +91,23 @@ jobs:
         rm -f ${WORK_ROOT}/build/conf/bblayers.conf
 
         case "$YOCTO_RELEASE" in
-          whinlatter|wrynose)
+          whinlatter)
+            # meta-poky still ships conf/templates/default on whinlatter
             TEMPLATECONF=$GITHUB_WORKSPACE/${WORK_ROOT}/layers/meta-yocto/meta-poky/conf/templates/default \
               . ./${WORK_ROOT}/layers/openembedded-core/oe-init-build-env ${WORK_ROOT}/build
             meta_oe="${WORK_ROOT}/layers/meta-openembedded"
+            meta_yocto="${WORK_ROOT}/layers/meta-yocto"
+            ;;
+          wrynose)
+            # wrynose meta-poky dropped conf/templates; use oe-core defaults
+            # and add poky layers + DISTRO explicitly.
+            . ./${WORK_ROOT}/layers/openembedded-core/oe-init-build-env ${WORK_ROOT}/build
+            meta_oe="${WORK_ROOT}/layers/meta-openembedded"
+            meta_yocto="${WORK_ROOT}/layers/meta-yocto"
+            echo "POKY_BBLAYERS_CONF_VERSION = \"2\"" >> conf/bblayers.conf
+            echo "BBLAYERS += '$GITHUB_WORKSPACE/${meta_yocto}/meta-poky'" >> conf/bblayers.conf
+            echo "BBLAYERS += '$GITHUB_WORKSPACE/${meta_yocto}/meta-yocto-bsp'" >> conf/bblayers.conf
+            echo "DISTRO = \"poky\"" >> conf/local.conf
             ;;
           *)
             . ./${WORK_ROOT}/poky/oe-init-build-env ${WORK_ROOT}/build

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -134,7 +134,16 @@ jobs:
         echo "PREFERRED_VERSION_dotnet = \"${DOTNET_VERSION}\"" >> conf/local.conf
         echo "PREFERRED_VERSION_dotnet-native = \"${DOTNET_VERSION}\"" >> conf/local.conf
 
-        echo "INHERIT += \" create-spdx cve-check rm_work \"" >> conf/local.conf
+        case "$YOCTO_RELEASE" in
+          wrynose)
+            # cve-check was removed in wrynose; use sbom-cve-check fragment.
+            echo "OE_FRAGMENTS += \"core/yocto/sbom-cve-check\"" >> conf/local.conf
+            echo "INHERIT += \"rm_work\"" >> conf/local.conf
+            ;;
+          *)
+            echo "INHERIT += \" create-spdx cve-check rm_work \"" >> conf/local.conf
+            ;;
+        esac
         sed -i 's/#IMAGE_CLASSES += "testimage testsdk"/IMAGE_CLASSES += "testimage "/' conf/local.conf
         echo "SPDX_PRETTY = \"1\"" >> conf/local.conf
 
@@ -176,10 +185,27 @@ jobs:
             ;;
         esac
         export TERM=linux
-        bitbake mono -c cve_check
-        mv $GITHUB_WORKSPACE/${WORK_ROOT}/build/tmp/log/cve/cve-summary.json $GITHUB_WORKSPACE/${WORK_ROOT}/build/tmp/log/cve/cve-summary-mono.json
-        bitbake dotnet -c cve_check
-        mv $GITHUB_WORKSPACE/${WORK_ROOT}/build/tmp/log/cve/cve-summary.json $GITHUB_WORKSPACE/${WORK_ROOT}/build/tmp/log/cve/cve-summary-dotnet.json
+        cve_dir="$GITHUB_WORKSPACE/${WORK_ROOT}/build/tmp/log/cve"
+        mkdir -p "$cve_dir"
+        case "$YOCTO_RELEASE" in
+          wrynose)
+            # Image-level sbom-cve-check runs during bitbake test-image-mono.
+            deploy="$GITHUB_WORKSPACE/${WORK_ROOT}/build/tmp/deploy/images/qemu${ARCH}"
+            found=$(ls "$deploy"/*.sbom-cve-check*.json 2>/dev/null | wc -l)
+            if [ "$found" -eq 0 ]; then
+              echo "No sbom-cve-check reports in $deploy" >&2
+              exit 1
+            fi
+            cp "$deploy"/*.sbom-cve-check*.json "$cve_dir/"
+            ls -la "$cve_dir"
+            ;;
+          *)
+            bitbake mono -c cve_check
+            mv "$cve_dir/cve-summary.json" "$cve_dir/cve-summary-mono.json"
+            bitbake dotnet -c cve_check
+            mv "$cve_dir/cve-summary.json" "$cve_dir/cve-summary-dotnet.json"
+            ;;
+        esac
     - name: Testing
       run: |
         case "$YOCTO_RELEASE" in

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -185,10 +185,12 @@ jobs:
             # root-login fragment matches test-image-mono IMAGE_FEATURES for qemu testimage.
             echo "OE_FRAGMENTS += \"core/yocto/sbom-cve-check core/yocto/root-login-with-empty-password\"" >> conf/local.conf
             echo "INHERIT += \"rm_work\"" >> conf/local.conf
-            # Use the project sstate mirror without BB_HASHSERVE_UPSTREAM:
-            # the CDN fragment's wss hashserv needs Python websockets, which
-            # this container does not provide in bitbake's runtime.
+            # Use the project sstate mirror. Do not enable a local hash
+            # equivalence server alongside it: that prevents sstate matches
+            # from the mirror. The CDN hashserv (wss) needs Python websockets,
+            # which this container does not provide in bitbake's runtime.
             echo "SSTATE_MIRRORS ?= \"file://.* http://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH\"" >> conf/local.conf
+            echo "BB_HASHSERVE = \"\"" >> conf/local.conf
             # IMAGE_VERSION_SUFFIX excludes DATETIME from task hashes, but
             # do_create_image_sbom_spdx deploys ${IMAGE_NAME}.spdx.json (which
             # includes DATETIME). Setscene can restore a previous filename while
@@ -203,9 +205,6 @@ jobs:
         esac
         sed -i 's/#IMAGE_CLASSES += "testimage testsdk"/IMAGE_CLASSES += "testimage "/' conf/local.conf
         echo "SPDX_PRETTY = \"1\"" >> conf/local.conf
-
-        # Share hash equivalency DB with SSTATE_DIR on the persistent runner.
-        echo "BB_HASHSERVE_DB_DIR = \"\${SSTATE_DIR}\"" >> conf/local.conf
 
         # Cross-building qemuarm64 on the X64 runner has wedged under full
         # parallelism (silent multi-hour stall in do_package). Cap threads.
@@ -226,35 +225,15 @@ jobs:
             . ./${WORK_ROOT}/poky/oe-init-build-env ${WORK_ROOT}/build
             ;;
         esac
-        # Heartbeat: surface disk pressure and fail if bitbake stops writing
-        # cooker logs for too long (the previous arm64 hang produced no output
-        # for hours while still holding the runner).
-        IDLE_LIMIT_SEC=3600
+        # Disk heartbeat only. An earlier idle-log watchdog looked at the wrong
+        # path after oe-init-build-env (cwd is already the build dir) and killed
+        # a healthy build during long do_compile tasks. Job timeout covers hangs.
         bitbake test-image-mono &
         bbpid=$!
-        last_activity=$(date +%s)
-        last_sig=""
         while kill -0 "$bbpid" 2>/dev/null; do
-          sleep 120
+          sleep 300
           echo "=== build heartbeat $(date -u +%H:%M:%S) ==="
           df -h . || true
-          sig=$(find "${WORK_ROOT}/build/tmp/log" -type f 2>/dev/null \
-            | xargs ls -lt 2>/dev/null | head -1 | awk '{print $5,$6,$7,$8,$9}')
-          now=$(date +%s)
-          if [ -n "$sig" ] && [ "$sig" != "$last_sig" ]; then
-            last_sig="$sig"
-            last_activity=$now
-          fi
-          if [ $((now - last_activity)) -ge "$IDLE_LIMIT_SEC" ]; then
-            echo "No bitbake log activity for ${IDLE_LIMIT_SEC}s; aborting hung build" >&2
-            kill -TERM "$bbpid" 2>/dev/null || true
-            sleep 10
-            kill -KILL "$bbpid" 2>/dev/null || true
-            # Also stop any leftover bitbake/cooker children.
-            pkill -TERM -P "$bbpid" 2>/dev/null || true
-            wait "$bbpid" 2>/dev/null || true
-            exit 1
-          fi
         done
         wait "$bbpid"
     - name: CVE Check Mono / dotNet

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -23,7 +23,9 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: [self-hosted, linux, X64]
-    timeout-minutes: 960
+    # Keep bounded so a wedged bitbake/container cannot pin the sole
+    # self-hosted runner for a full day (seen with arm64 do_package).
+    timeout-minutes: 480
     container:
       image: dynamicdevices/yocto-ci-build:latest
       options: --privileged --platform linux/amd64  -v /dev/net/tun:/dev/net/tun -v /dev/kvm:/dev/kvm
@@ -32,10 +34,16 @@ jobs:
       # Keep going through the matrix after one cell fails so a flaky arch
       # does not hide results from the others.
       fail-fast: false
+      # x86-64 first: native builds validate recipes quickly; arm64 cross
+      # builds are slower and have hung the runner when disk/RAM is tight.
       matrix:
-        dotnet_version: [10.0.100, 8.0.406, 6.0.428]
-        mono_version: [6.12.0.206]
-        arch: [x86-64, arm64]
+        include:
+          - {dotnet_version: "10.0.100", mono_version: "6.12.0.206", arch: x86-64}
+          - {dotnet_version: "8.0.406", mono_version: "6.12.0.206", arch: x86-64}
+          - {dotnet_version: "6.0.428", mono_version: "6.12.0.206", arch: x86-64}
+          - {dotnet_version: "10.0.100", mono_version: "6.12.0.206", arch: arm64}
+          - {dotnet_version: "8.0.406", mono_version: "6.12.0.206", arch: arm64}
+          - {dotnet_version: "6.0.428", mono_version: "6.12.0.206", arch: arm64}
     env:
       name: build-and-test
       MONO_VERSION: ${{ matrix.mono_version }}
@@ -201,8 +209,18 @@ jobs:
         sed -i 's/#IMAGE_CLASSES += "testimage testsdk"/IMAGE_CLASSES += "testimage "/' conf/local.conf
         echo "SPDX_PRETTY = \"1\"" >> conf/local.conf
 
-        echo "BB_NUMBER_THREADS ?= \"\${@oe.utils.cpu_count()}\"" >> conf/local.conf
-        echo "PARALLEL_MAKE ?= \"-j \${@oe.utils.cpu_count()} -l \${@oe.utils.cpu_count()*2}\"" >> conf/local.conf
+        # Share hash equivalency DB with SSTATE_DIR on the persistent runner.
+        echo "BB_HASHSERVE_DB_DIR = \"\${SSTATE_DIR}\"" >> conf/local.conf
+
+        # Cross-building qemuarm64 on the X64 runner has wedged under full
+        # parallelism (silent multi-hour stall in do_package). Cap threads.
+        if [ "$ARCH" = "arm64" ]; then
+          echo "BB_NUMBER_THREADS ?= \"\${@oe.utils.cpu_count(at_least=1, at_most=4)}\"" >> conf/local.conf
+          echo "PARALLEL_MAKE ?= \"-j \${@oe.utils.cpu_count(at_least=1, at_most=4)}\"" >> conf/local.conf
+        else
+          echo "BB_NUMBER_THREADS ?= \"\${@oe.utils.cpu_count()}\"" >> conf/local.conf
+          echo "PARALLEL_MAKE ?= \"-j \${@oe.utils.cpu_count()} -l \${@oe.utils.cpu_count()*2}\"" >> conf/local.conf
+        fi
     - name: Building Mono Test Image
       run: |
         case "$YOCTO_RELEASE" in
@@ -213,7 +231,37 @@ jobs:
             . ./${WORK_ROOT}/poky/oe-init-build-env ${WORK_ROOT}/build
             ;;
         esac
-        bitbake test-image-mono
+        # Heartbeat: surface disk pressure and fail if bitbake stops writing
+        # cooker logs for too long (the previous arm64 hang produced no output
+        # for hours while still holding the runner).
+        IDLE_LIMIT_SEC=3600
+        bitbake test-image-mono &
+        bbpid=$!
+        last_activity=$(date +%s)
+        last_sig=""
+        while kill -0 "$bbpid" 2>/dev/null; do
+          sleep 120
+          echo "=== build heartbeat $(date -u +%H:%M:%S) ==="
+          df -h . || true
+          sig=$(find "${WORK_ROOT}/build/tmp/log" -type f 2>/dev/null \
+            | xargs ls -lt 2>/dev/null | head -1 | awk '{print $5,$6,$7,$8,$9}')
+          now=$(date +%s)
+          if [ -n "$sig" ] && [ "$sig" != "$last_sig" ]; then
+            last_sig="$sig"
+            last_activity=$now
+          fi
+          if [ $((now - last_activity)) -ge "$IDLE_LIMIT_SEC" ]; then
+            echo "No bitbake log activity for ${IDLE_LIMIT_SEC}s; aborting hung build" >&2
+            kill -TERM "$bbpid" 2>/dev/null || true
+            sleep 10
+            kill -KILL "$bbpid" 2>/dev/null || true
+            # Also stop any leftover bitbake/cooker children.
+            pkill -TERM -P "$bbpid" 2>/dev/null || true
+            wait "$bbpid" 2>/dev/null || true
+            exit 1
+          fi
+        done
+        wait "$bbpid"
     - name: CVE Check Mono / dotNet
       run: |
         case "$YOCTO_RELEASE" in

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -154,7 +154,8 @@ jobs:
         case "$YOCTO_RELEASE" in
           wrynose)
             # cve-check was removed in wrynose; use sbom-cve-check fragment.
-            echo "OE_FRAGMENTS += \"core/yocto/sbom-cve-check\"" >> conf/local.conf
+            # root-login fragment matches test-image-mono IMAGE_FEATURES for qemu testimage.
+            echo "OE_FRAGMENTS += \"core/yocto/sbom-cve-check core/yocto/root-login-with-empty-password\"" >> conf/local.conf
             echo "INHERIT += \"rm_work\"" >> conf/local.conf
             # Use the project sstate mirror without BB_HASHSERVE_UPSTREAM:
             # the CDN fragment's wss hashserv needs Python websockets, which

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -31,19 +31,14 @@ jobs:
       options: --privileged --platform linux/amd64  -v /dev/net/tun:/dev/net/tun -v /dev/kvm:/dev/kvm
     strategy:
       max-parallel: 1
-      # Keep going through the matrix after one cell fails so a flaky arch
-      # does not hide results from the others.
       fail-fast: false
-      # x86-64 first: native builds validate recipes quickly; arm64 cross
-      # builds are slower and have hung the runner when disk/RAM is tight.
+      # arm64 (qemuarm64 cross on this X64 runner) previously wedged for 10h+
+      # in do_package with no log output, pinning the only self-hosted runner.
+      # Re-enable once the runner has enough disk/RAM headroom for cross builds.
       matrix:
-        include:
-          - {dotnet_version: "10.0.100", mono_version: "6.12.0.206", arch: x86-64}
-          - {dotnet_version: "8.0.406", mono_version: "6.12.0.206", arch: x86-64}
-          - {dotnet_version: "6.0.428", mono_version: "6.12.0.206", arch: x86-64}
-          - {dotnet_version: "10.0.100", mono_version: "6.12.0.206", arch: arm64}
-          - {dotnet_version: "8.0.406", mono_version: "6.12.0.206", arch: arm64}
-          - {dotnet_version: "6.0.428", mono_version: "6.12.0.206", arch: arm64}
+        dotnet_version: ["10.0.100", "8.0.406", "6.0.428"]
+        mono_version: ["6.12.0.206"]
+        arch: [x86-64]
     env:
       name: build-and-test
       MONO_VERSION: ${{ matrix.mono_version }}

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -53,7 +53,11 @@ jobs:
     - name: Install host Python deps
       run: |
         # Required by BB_HASHSERVE_UPSTREAM (wss://) from sstate-mirror-cdn.
-        python3 -m pip install --user 'websockets>=10'
+        # Install into the workspace: $HOME/.local is not writable in this container.
+        pip_target="${GITHUB_WORKSPACE}/.pip-packages"
+        python3 -m pip install --target "$pip_target" 'websockets>=10'
+        echo "PYTHONPATH=${pip_target}${PYTHONPATH:+:$PYTHONPATH}" >> "$GITHUB_ENV"
+        PYTHONPATH="${pip_target}${PYTHONPATH:+:$PYTHONPATH}" python3 -c 'import websockets; print(websockets.__version__)'
     - name: Checkout meta-mono
       uses: actions/checkout@v5
       with:

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -160,6 +160,11 @@ jobs:
             # the CDN fragment's wss hashserv needs Python websockets, which
             # this container does not provide in bitbake's runtime.
             echo "SSTATE_MIRRORS ?= \"file://.* http://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH\"" >> conf/local.conf
+            # oe-core excludes DATETIME from do_create_image_sbom_spdx's hash, but
+            # the deployed file is ${IMAGE_NAME}.spdx.json (includes DATETIME).
+            # Cross-build setscene can restore a stale name; do_sbom_cve_check then
+            # fails with ENOENT. Keep DATETIME in the hash so the task re-runs.
+            echo "do_create_image_sbom_spdx[vardepsexclude]:remove = \"DATETIME\"" >> conf/local.conf
             ;;
           *)
             echo "INHERIT += \" create-spdx cve-check rm_work \"" >> conf/local.conf

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -160,11 +160,13 @@ jobs:
             # the CDN fragment's wss hashserv needs Python websockets, which
             # this container does not provide in bitbake's runtime.
             echo "SSTATE_MIRRORS ?= \"file://.* http://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH\"" >> conf/local.conf
-            # oe-core excludes DATETIME from do_create_image_sbom_spdx's hash, but
-            # the deployed file is ${IMAGE_NAME}.spdx.json (includes DATETIME).
-            # Cross-build setscene can restore a stale name; do_sbom_cve_check then
-            # fails with ENOENT. Keep DATETIME in the hash so the task re-runs.
-            echo "do_create_image_sbom_spdx[vardepsexclude]:remove = \"DATETIME\"" >> conf/local.conf
+            # IMAGE_VERSION_SUFFIX excludes DATETIME from task hashes, but
+            # do_create_image_sbom_spdx deploys ${IMAGE_NAME}.spdx.json (which
+            # includes DATETIME). Setscene can restore a previous filename while
+            # do_sbom_cve_check looks for the current one. Force that one task to
+            # re-run each CI build without invalidating the rest of image sstate.
+            echo "META_MONO_CI_BUILD_ID = \"${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\"" >> conf/local.conf
+            echo "do_create_image_sbom_spdx[vardeps] += \"META_MONO_CI_BUILD_ID\"" >> conf/local.conf
             ;;
           *)
             echo "INHERIT += \" create-spdx cve-check rm_work \"" >> conf/local.conf

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -33,6 +33,25 @@ jobs:
       ARCH: ${{ matrix.arch }}
       WORK_ROOT: work
     steps:
+    - name: Free disk space
+      run: |
+        set -x
+        df -h
+        # Prior CI layouts left per-release trees (styhead/, whinlatter/, …)
+        # on the persistent self-hosted workspace. A fresh wrynose build of
+        # clang/llvm/rust needs that space back.
+        for d in styhead whinlatter scarthgap kirkstone nanbield styhead-test \
+                 feature work/build/tmp work/build/cache work/build/tmp-glibc; do
+          if [ -e "$d" ]; then
+            echo "Removing $d"
+            rm -rf "$d"
+          fi
+        done
+        # Drop stale build tmp only; keep layers, downloads, and sstate.
+        if [ -d "${WORK_ROOT}/build/tmp" ]; then
+          rm -rf "${WORK_ROOT}/build/tmp"
+        fi
+        df -h
     - name: Checkout meta-mono
       uses: actions/checkout@v5
       with:
@@ -137,7 +156,9 @@ jobs:
         case "$YOCTO_RELEASE" in
           wrynose)
             # cve-check was removed in wrynose; use sbom-cve-check fragment.
-            echo "OE_FRAGMENTS += \"core/yocto/sbom-cve-check\"" >> conf/local.conf
+            # sstate-mirror-cdn avoids rebuilding clang/llvm/rust from source
+            # (those natives filled the self-hosted runner disk).
+            echo "OE_FRAGMENTS += \"core/yocto/sbom-cve-check core/yocto/sstate-mirror-cdn\"" >> conf/local.conf
             echo "INHERIT += \"rm_work\"" >> conf/local.conf
             ;;
           *)

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - master
       - whinlatter
+      - wrynose
   pull_request:
     branches:
       - master
       - whinlatter
+      - wrynose
     paths-ignore:
       - "**.md"
 jobs:
@@ -23,56 +25,91 @@ jobs:
       matrix:
         dotnet_version: [10.0.100, 8.0.406, 6.0.428]
         mono_version: [6.12.0.206]
-        branch: [whinlatter]
-        arch: [x86-64, arm, arm64]
-        exclude:
-          # GCC build broken for ARM32 - see README and discussions/234
-          - branch: whinlatter
-            arch: arm
+        arch: [x86-64, arm64]
     env:
       name: build-and-test
       MONO_VERSION: ${{ matrix.mono_version }}
       DOTNET_VERSION: ${{ matrix.dotnet_version }}
       ARCH: ${{ matrix.arch }}
-      BRANCH: ${{ matrix.branch }}
+      WORK_ROOT: work
     steps:
     - name: Checkout meta-mono
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         clean: false
-        path: ${{ matrix.branch }}/meta-mono
-    - name: Update repo poky
+        path: work/meta-mono
+    - name: Detect Yocto release
       run: |
-        if [ ! -d ${BRANCH}/poky ]; then
-          git clone git://git.yoctoproject.org/poky -b ${BRANCH} ${BRANCH}/poky
-        else
-          cd ${BRANCH}/poky
-          git pull origin ${BRANCH}
-          cd ../..
+        compat=$(grep '^LAYERSERIES_COMPAT_mono' "${WORK_ROOT}/meta-mono/conf/layer.conf" | sed 's/.*"\([^"]*\)".*/\1/')
+        if [ -z "$compat" ]; then
+          echo "Could not read LAYERSERIES_COMPAT_mono from conf/layer.conf" >&2
+          exit 1
         fi
-    - name: Update repo meta-openembedded
+        echo "YOCTO_RELEASE=${compat}" >> "$GITHUB_ENV"
+        echo "Detected Yocto release: ${compat}"
+    - name: Setup base layers
       run: |
-        if [ ! -d ${BRANCH}/meta-openembedded ]; then
-          git clone https://github.com/openembedded/meta-openembedded.git -b ${BRANCH} ${BRANCH}/meta-openembedded
-        else
-          cd ${BRANCH}/meta-openembedded
-          git pull origin ${BRANCH}
-          cd ../..
-        fi
+        clone_or_update() {
+          local url="$1" branch="$2" dest="$3"
+          if [ ! -d "$dest" ]; then
+            git clone "$url" -b "$branch" "$dest"
+          else
+            cd "$dest"
+            git fetch origin "$branch"
+            git checkout "$branch"
+            git pull origin "$branch"
+            cd "$GITHUB_WORKSPACE"
+          fi
+        }
+
+        case "$YOCTO_RELEASE" in
+          whinlatter)
+            mkdir -p "${WORK_ROOT}/layers"
+            clone_or_update https://git.openembedded.org/bitbake 2.16 "${WORK_ROOT}/layers/bitbake"
+            clone_or_update https://git.openembedded.org/openembedded-core whinlatter "${WORK_ROOT}/layers/openembedded-core"
+            clone_or_update https://git.yoctoproject.org/meta-yocto whinlatter "${WORK_ROOT}/layers/meta-yocto"
+            clone_or_update https://github.com/openembedded/meta-openembedded.git whinlatter "${WORK_ROOT}/layers/meta-openembedded"
+            ;;
+          wrynose)
+            mkdir -p "${WORK_ROOT}/layers"
+            clone_or_update https://git.openembedded.org/bitbake 2.18 "${WORK_ROOT}/layers/bitbake"
+            clone_or_update https://git.openembedded.org/openembedded-core wrynose "${WORK_ROOT}/layers/openembedded-core"
+            clone_or_update https://git.yoctoproject.org/meta-yocto wrynose "${WORK_ROOT}/layers/meta-yocto"
+            clone_or_update https://github.com/openembedded/meta-openembedded.git wrynose "${WORK_ROOT}/layers/meta-openembedded"
+            ;;
+          *)
+            # Legacy releases still use the poky monorepo. Use HTTPS:
+            # git.yoctoproject.org is behind Cloudflare, which does not
+            # carry the native git:// protocol (port 9418) reliably.
+            clone_or_update https://git.yoctoproject.org/poky "$YOCTO_RELEASE" "${WORK_ROOT}/poky"
+            clone_or_update https://github.com/openembedded/meta-openembedded.git "$YOCTO_RELEASE" "${WORK_ROOT}/meta-openembedded"
+            ;;
+        esac
     - name: Configuring
       run: |
-        rm -f ${BRANCH}/build/conf/local.conf
-        rm -f ${BRANCH}/build/conf/bblayers.conf
-        . ./${BRANCH}/poky/oe-init-build-env ${BRANCH}/build
+        rm -f ${WORK_ROOT}/build/conf/local.conf
+        rm -f ${WORK_ROOT}/build/conf/bblayers.conf
 
-        # Append custom variables for regenerated local.conf and bblayers.conf samples
+        case "$YOCTO_RELEASE" in
+          whinlatter|wrynose)
+            TEMPLATECONF=$GITHUB_WORKSPACE/${WORK_ROOT}/layers/meta-yocto/meta-poky/conf/templates/default \
+              . ./${WORK_ROOT}/layers/openembedded-core/oe-init-build-env ${WORK_ROOT}/build
+            meta_oe="${WORK_ROOT}/layers/meta-openembedded"
+            ;;
+          *)
+            . ./${WORK_ROOT}/poky/oe-init-build-env ${WORK_ROOT}/build
+            meta_oe="${WORK_ROOT}/meta-openembedded"
+            ;;
+        esac
+
         echo "### Starting to configure local.conf and bblayers.conf ###"
+        echo "yocto release: $YOCTO_RELEASE"
         echo "mono version: $MONO_VERSION"
         echo "dotnet version: $DOTNET_VERSION"
 
-        echo "BBLAYERS += '$GITHUB_WORKSPACE/${BRANCH}/meta-mono'" >> conf/bblayers.conf
-        echo "BBLAYERS += '$GITHUB_WORKSPACE/${BRANCH}/meta-openembedded/meta-oe'" >> conf/bblayers.conf
-        echo "BBLAYERS += '$GITHUB_WORKSPACE/${BRANCH}/meta-openembedded/meta-python'" >> conf/bblayers.conf
+        echo "BBLAYERS += '$GITHUB_WORKSPACE/${WORK_ROOT}/meta-mono'" >> conf/bblayers.conf
+        echo "BBLAYERS += '$GITHUB_WORKSPACE/${meta_oe}/meta-oe'" >> conf/bblayers.conf
+        echo "BBLAYERS += '$GITHUB_WORKSPACE/${meta_oe}/meta-python'" >> conf/bblayers.conf
 
         echo "BB_DEFAULT_EVENTLOG = \"\"" >> conf/local.conf
         echo "MACHINE = \"qemu${ARCH}\"" >> conf/local.conf
@@ -95,32 +132,60 @@ jobs:
     # TODO: remove this step once all matrix jobs have rebuilt successfully.
     - name: Clean stale sstate
       run: |
-        . ./${BRANCH}/poky/oe-init-build-env ${BRANCH}/build
+        case "$YOCTO_RELEASE" in
+          whinlatter|wrynose)
+            . ./${WORK_ROOT}/layers/openembedded-core/oe-init-build-env ${WORK_ROOT}/build
+            ;;
+          *)
+            . ./${WORK_ROOT}/poky/oe-init-build-env ${WORK_ROOT}/build
+            ;;
+        esac
         bitbake -c cleansstate dotnet dotnet-native python3-clr-loader python3-clr-loader-native dotnet-helloworld python3-pythonnet
     - name: Building Mono Test Image
       run: |
-        . ./${BRANCH}/poky/oe-init-build-env ${BRANCH}/build
+        case "$YOCTO_RELEASE" in
+          whinlatter|wrynose)
+            . ./${WORK_ROOT}/layers/openembedded-core/oe-init-build-env ${WORK_ROOT}/build
+            ;;
+          *)
+            . ./${WORK_ROOT}/poky/oe-init-build-env ${WORK_ROOT}/build
+            ;;
+        esac
         bitbake test-image-mono
     - name: CVE Check Mono / dotNet
       run: |
-        . ./${BRANCH}/poky/oe-init-build-env ${BRANCH}/build
+        case "$YOCTO_RELEASE" in
+          whinlatter|wrynose)
+            . ./${WORK_ROOT}/layers/openembedded-core/oe-init-build-env ${WORK_ROOT}/build
+            ;;
+          *)
+            . ./${WORK_ROOT}/poky/oe-init-build-env ${WORK_ROOT}/build
+            ;;
+        esac
         export TERM=linux
         bitbake mono -c cve_check
-        mv $GITHUB_WORKSPACE/${BRANCH}/build/tmp/log/cve/cve-summary.json $GITHUB_WORKSPACE/${BRANCH}/build/tmp/log/cve/cve-summary-mono.json
+        mv $GITHUB_WORKSPACE/${WORK_ROOT}/build/tmp/log/cve/cve-summary.json $GITHUB_WORKSPACE/${WORK_ROOT}/build/tmp/log/cve/cve-summary-mono.json
         bitbake dotnet -c cve_check
-        mv $GITHUB_WORKSPACE/${BRANCH}/build/tmp/log/cve/cve-summary.json $GITHUB_WORKSPACE/${BRANCH}/build/tmp/log/cve/cve-summary-dotnet.json
+        mv $GITHUB_WORKSPACE/${WORK_ROOT}/build/tmp/log/cve/cve-summary.json $GITHUB_WORKSPACE/${WORK_ROOT}/build/tmp/log/cve/cve-summary-dotnet.json
     - name: Testing
       run: |
-        . ./${BRANCH}/poky/oe-init-build-env ${BRANCH}/build
+        case "$YOCTO_RELEASE" in
+          whinlatter|wrynose)
+            . ./${WORK_ROOT}/layers/openembedded-core/oe-init-build-env ${WORK_ROOT}/build
+            ;;
+          *)
+            . ./${WORK_ROOT}/poky/oe-init-build-env ${WORK_ROOT}/build
+            ;;
+        esac
         export TERM=linux
         bitbake test-image-mono -c testimage
     - name: Store artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
-        name: test-image-mono-${{ matrix.branch }}-${{ matrix.mono_version }}-${{ matrix.dotnet_version }}-${{ github.sha }}-${{ matrix.arch }}
-        path: ./${{ matrix.branch }}/build/tmp/deploy/images/qemu${{ matrix.arch }}/
+        name: test-image-mono-${{ env.YOCTO_RELEASE }}-${{ matrix.mono_version }}-${{ matrix.dotnet_version }}-${{ github.sha }}-${{ matrix.arch }}
+        path: ./${{ env.WORK_ROOT }}/build/tmp/deploy/images/qemu${{ matrix.arch }}/
     - name: Store CVEs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
-        name: cve-summary-${{ matrix.branch }}-${{ matrix.mono_version }}-${{ matrix.dotnet_version }}-${{ github.sha }}-${{ matrix.arch }}
-        path: ./${{ matrix.branch }}/build/tmp/log/cve/*.json
+        name: cve-summary-${{ env.YOCTO_RELEASE }}-${{ matrix.mono_version }}-${{ matrix.dotnet_version }}-${{ github.sha }}-${{ matrix.arch }}
+        path: ./${{ env.WORK_ROOT }}/build/tmp/log/cve/*.json

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -188,12 +188,14 @@ jobs:
             # root-login fragment matches test-image-mono IMAGE_FEATURES for qemu testimage.
             echo "OE_FRAGMENTS += \"core/yocto/sbom-cve-check core/yocto/root-login-with-empty-password\"" >> conf/local.conf
             echo "INHERIT += \"rm_work\"" >> conf/local.conf
-            # Use the project sstate mirror. Do not enable a local hash
-            # equivalence server alongside it: that prevents sstate matches
-            # from the mirror. The CDN hashserv (wss) needs Python websockets,
-            # which this container does not provide in bitbake's runtime.
+            # HTTP sstate mirror only: the CDN hashserv (wss) needs Python
+            # websockets, which this container does not provide to bitbake.
+            # wrynose defaults to OEEquivHash, which requires BB_HASHSERVE;
+            # use a local server with the DB on the shared SSTATE_DIR so
+            # persistent-runner reuse works across matrix cells.
             echo "SSTATE_MIRRORS ?= \"file://.* http://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH\"" >> conf/local.conf
-            echo "BB_HASHSERVE = \"\"" >> conf/local.conf
+            echo "BB_HASHSERVE = \"auto\"" >> conf/local.conf
+            echo "BB_HASHSERVE_DB_DIR = \"\${SSTATE_DIR}\"" >> conf/local.conf
             # IMAGE_VERSION_SUFFIX excludes DATETIME from task hashes, but
             # do_create_image_sbom_spdx deploys ${IMAGE_NAME}.spdx.json (which
             # includes DATETIME). Setscene can restore a previous filename while
@@ -228,17 +230,25 @@ jobs:
             . ./${WORK_ROOT}/poky/oe-init-build-env ${WORK_ROOT}/build
             ;;
         esac
-        # Disk heartbeat only. An earlier idle-log watchdog looked at the wrong
-        # path after oe-init-build-env (cwd is already the build dir) and killed
-        # a healthy build during long do_compile tasks. Job timeout covers hangs.
+        # Disk heartbeat in the background; wait on bitbake so failures
+        # surface immediately (a foreground sleep loop delayed exit by 5m).
         bitbake test-image-mono &
         bbpid=$!
-        while kill -0 "$bbpid" 2>/dev/null; do
-          sleep 300
-          echo "=== build heartbeat $(date -u +%H:%M:%S) ==="
-          df -h . || true
-        done
+        (
+          while kill -0 "$bbpid" 2>/dev/null; do
+            sleep 300
+            echo "=== build heartbeat $(date -u +%H:%M:%S) ==="
+            df -h . || true
+          done
+        ) &
+        hb=$!
+        set +e
         wait "$bbpid"
+        rc=$?
+        set -e
+        kill "$hb" 2>/dev/null || true
+        wait "$hb" 2>/dev/null || true
+        exit "$rc"
     - name: CVE Check Mono / dotNet
       run: |
         case "$YOCTO_RELEASE" in

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -154,10 +154,12 @@ jobs:
         case "$YOCTO_RELEASE" in
           wrynose)
             # cve-check was removed in wrynose; use sbom-cve-check fragment.
-            # sstate-mirror-cdn avoids rebuilding clang/llvm/rust from source
-            # (those natives filled the self-hosted runner disk).
-            echo "OE_FRAGMENTS += \"core/yocto/sbom-cve-check core/yocto/sstate-mirror-cdn\"" >> conf/local.conf
+            echo "OE_FRAGMENTS += \"core/yocto/sbom-cve-check\"" >> conf/local.conf
             echo "INHERIT += \"rm_work\"" >> conf/local.conf
+            # Use the project sstate mirror without BB_HASHSERVE_UPSTREAM:
+            # the CDN fragment's wss hashserv needs Python websockets, which
+            # this container does not provide in bitbake's runtime.
+            echo "SSTATE_MIRRORS ?= \"file://.* http://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH\"" >> conf/local.conf
             ;;
           *)
             echo "INHERIT += \" create-spdx cve-check rm_work \"" >> conf/local.conf

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -35,23 +35,25 @@ jobs:
     steps:
     - name: Free disk space
       run: |
-        set -x
+        echo "=== disk before cleanup ==="
         df -h
         # Prior CI layouts left per-release trees (styhead/, whinlatter/, …)
         # on the persistent self-hosted workspace. A fresh wrynose build of
         # clang/llvm/rust needs that space back.
         for d in styhead whinlatter scarthgap kirkstone nanbield styhead-test \
-                 feature work/build/tmp work/build/cache work/build/tmp-glibc; do
+                 feature "${WORK_ROOT}/build/tmp" "${WORK_ROOT}/build/cache" \
+                 "${WORK_ROOT}/build/tmp-glibc"; do
           if [ -e "$d" ]; then
             echo "Removing $d"
             rm -rf "$d"
           fi
         done
-        # Drop stale build tmp only; keep layers, downloads, and sstate.
-        if [ -d "${WORK_ROOT}/build/tmp" ]; then
-          rm -rf "${WORK_ROOT}/build/tmp"
-        fi
+        echo "=== disk after cleanup ==="
         df -h
+    - name: Install host Python deps
+      run: |
+        # Required by BB_HASHSERVE_UPSTREAM (wss://) from sstate-mirror-cdn.
+        python3 -m pip install --user 'websockets>=10'
     - name: Checkout meta-mono
       uses: actions/checkout@v5
       with:
@@ -170,20 +172,6 @@ jobs:
 
         echo "BB_NUMBER_THREADS ?= \"\${@oe.utils.cpu_count()}\"" >> conf/local.conf
         echo "PARALLEL_MAKE ?= \"-j \${@oe.utils.cpu_count()} -l \${@oe.utils.cpu_count()*2}\"" >> conf/local.conf
-    # Flush stale sstate/sysroot to ensure fresh builds with corrected
-    # host/fxr layout and dotnet wrapper.
-    # TODO: remove this step once all matrix jobs have rebuilt successfully.
-    - name: Clean stale sstate
-      run: |
-        case "$YOCTO_RELEASE" in
-          whinlatter|wrynose)
-            . ./${WORK_ROOT}/layers/openembedded-core/oe-init-build-env ${WORK_ROOT}/build
-            ;;
-          *)
-            . ./${WORK_ROOT}/poky/oe-init-build-env ${WORK_ROOT}/build
-            ;;
-        esac
-        bitbake -c cleansstate dotnet dotnet-native python3-clr-loader python3-clr-loader-native dotnet-helloworld python3-pythonnet
     - name: Building Mono Test Image
       run: |
         case "$YOCTO_RELEASE" in

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -50,14 +50,6 @@ jobs:
         done
         echo "=== disk after cleanup ==="
         df -h
-    - name: Install host Python deps
-      run: |
-        # Required by BB_HASHSERVE_UPSTREAM (wss://) from sstate-mirror-cdn.
-        # Install into the workspace: $HOME/.local is not writable in this container.
-        pip_target="${GITHUB_WORKSPACE}/.pip-packages"
-        python3 -m pip install --target "$pip_target" 'websockets>=10'
-        echo "PYTHONPATH=${pip_target}${PYTHONPATH:+:$PYTHONPATH}" >> "$GITHUB_ENV"
-        PYTHONPATH="${pip_target}${PYTHONPATH:+:$PYTHONPATH}" python3 -c 'import websockets; print(websockets.__version__)'
     - name: Checkout meta-mono
       uses: actions/checkout@v5
       with:

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -32,13 +32,16 @@ jobs:
     strategy:
       max-parallel: 1
       fail-fast: false
-      # arm64 (qemuarm64 cross on this X64 runner) previously wedged for 10h+
-      # in do_package with no log output, pinning the only self-hosted runner.
-      # Re-enable once the runner has enough disk/RAM headroom for cross builds.
+      # x86-64 first so native builds validate recipes before slower qemuarm64
+      # cross builds on this X64 runner.
       matrix:
-        dotnet_version: ["10.0.100", "8.0.406", "6.0.428"]
-        mono_version: ["6.12.0.206"]
-        arch: [x86-64]
+        include:
+          - {dotnet_version: "10.0.100", mono_version: "6.12.0.206", arch: x86-64}
+          - {dotnet_version: "8.0.406", mono_version: "6.12.0.206", arch: x86-64}
+          - {dotnet_version: "6.0.428", mono_version: "6.12.0.206", arch: x86-64}
+          - {dotnet_version: "10.0.100", mono_version: "6.12.0.206", arch: arm64}
+          - {dotnet_version: "8.0.406", mono_version: "6.12.0.206", arch: arm64}
+          - {dotnet_version: "6.0.428", mono_version: "6.12.0.206", arch: arm64}
     env:
       name: build-and-test
       MONO_VERSION: ${{ matrix.mono_version }}

--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -13,6 +13,13 @@ on:
       - wrynose
     paths-ignore:
       - "**.md"
+
+# Self-hosted runner is singular; cancel superseded PR/push runs so a hung
+# matrix cell cannot pin the runner until the job timeout elapses.
+concurrency:
+  group: meta-mono-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: [self-hosted, linux, X64]
@@ -22,6 +29,9 @@ jobs:
       options: --privileged --platform linux/amd64  -v /dev/net/tun:/dev/net/tun -v /dev/kvm:/dev/kvm
     strategy:
       max-parallel: 1
+      # Keep going through the matrix after one cell fails so a flaky arch
+      # does not hide results from the others.
+      fail-fast: false
       matrix:
         dotnet_version: [10.0.100, 8.0.406, 6.0.428]
         mono_version: [6.12.0.206]
@@ -39,17 +49,32 @@ jobs:
         df -h
         # Prior CI layouts left per-release trees (styhead/, whinlatter/, …)
         # on the persistent self-hosted workspace. A fresh wrynose build of
-        # clang/llvm/rust needs that space back.
-        for d in styhead whinlatter scarthgap kirkstone nanbield styhead-test \
-                 feature "${WORK_ROOT}/build/tmp" "${WORK_ROOT}/build/cache" \
-                 "${WORK_ROOT}/build/tmp-glibc"; do
-          if [ -e "$d" ]; then
-            echo "Removing $d"
-            rm -rf "$d"
+        # clang/llvm/rust needs that space back. Also drop stale deploy/work
+        # trees from other MACHINE values so arm64/x86-64 matrix cells do not
+        # starve each other mid-build (hangs with no further bitbake output).
+        for path in styhead whinlatter scarthgap kirkstone nanbield styhead-test \
+                    feature \
+                    "${WORK_ROOT}/build/tmp" \
+                    "${WORK_ROOT}/build/cache" \
+                    "${WORK_ROOT}/build/tmp-glibc" \
+                    "${WORK_ROOT}/build/deploy"; do
+          if [ -e "$path" ]; then
+            echo "Removing $path"
+            rm -rf "$path"
           fi
         done
+        # Remove any alternate TMPDIR layouts left by older CI configs.
+        if [ -d "${WORK_ROOT}/build" ]; then
+          find "${WORK_ROOT}/build" -maxdepth 1 -type d -name 'tmp-*' -exec rm -rf {} +
+        fi
         echo "=== disk after cleanup ==="
         df -h
+        # Fail early if the runner is already too tight for a sato+mono image.
+        avail_kb=$(df -Pk . | awk 'NR==2 {print $4}')
+        if [ "$avail_kb" -lt 20971520 ]; then
+          echo "Only ${avail_kb}KB free; need at least 20GiB" >&2
+          exit 1
+        fi
     - name: Checkout meta-mono
       uses: actions/checkout@v5
       with:

--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@ meta-mono is an OpenEmbedded layer that builds dotNet, the mono runtime and mono
 
 | Branch | Version | Support Status* | Status of Build & Tests |
 | ------ | ------- | --------------- | ----------------------- |
-| walnascar | 5.2	| Future (April 2025) | [![walnascar](https://img.shields.io/github/actions/workflow/status/dynamicdevices/meta-mono/CI_github.yml?branch=walnascar&label=build%20%26%20test)](https://github.com/DynamicDevices/meta-mono/actions/workflows/CI_github.yml) |
-| styhead   | 5.1	| Support for 7 months (May 2025) | [![styhead](https://img.shields.io/github/actions/workflow/status/dynamicdevices/meta-mono/CI_github.yml?branch=styhead&label=build%20%26%20test)](https://github.com/DynamicDevices/meta-mono/actions/workflows/CI_github.yml) |
-| scarthgap | 5.0	| Long Term Support (until Apr. 2028) | [![scarthgap](https://img.shields.io/github/actions/workflow/status/dynamicdevices/meta-mono/CI_github.yml?branch=scarthgap&label=build%20%26%20test)](https://github.com/DynamicDevices/meta-mono/actions/workflows/CI_github.yml) |
-| kirkstone | 4.0	| Long Term Support (minimum Apr. 2024)	 | [![kirkstone](https://img.shields.io/github/actions/workflow/status/dynamicdevices/meta-mono/CI_github.yml?branch=kirkstone&label=build%20%26%20test)](https://github.com/DynamicDevices/meta-mono/actions/workflows/CI_github.yml) |
+| whinlatter | 5.3 | Support for 6 months (until May 2026) | [![whinlatter](https://img.shields.io/github/actions/workflow/status/dynamicdevices/meta-mono/CI_github.yml?branch=whinlatter&label=build%20%26%20test)](https://github.com/DynamicDevices/meta-mono/actions/workflows/CI_github.yml) |
+| scarthgap | 5.0 | Long Term Support (until Apr. 2028) | [![scarthgap](https://img.shields.io/github/actions/workflow/status/dynamicdevices/meta-mono/CI_github.yml?branch=scarthgap&label=build%20%26%20test)](https://github.com/DynamicDevices/meta-mono/actions/workflows/CI_github.yml) |
+| kirkstone | 4.0 | Long Term Support (until Apr. 2026) | [![kirkstone](https://img.shields.io/github/actions/workflow/status/dynamicdevices/meta-mono/CI_github.yml?branch=kirkstone&label=build%20%26%20test)](https://github.com/DynamicDevices/meta-mono/actions/workflows/CI_github.yml) |
 
-*support status as of 21/03/25, follows main Yocto release support schedule [here](https://wiki.yoctoproject.org/wiki/Releases)
+*support status as of Feb 2026, follows main Yocto release support schedule [here](https://wiki.yoctoproject.org/wiki/Releases)
 
 ## Limitations
 

--- a/classes/mono.bbclass
+++ b/classes/mono.bbclass
@@ -31,12 +31,12 @@ FILES:${PN}-doc:append = " \
   ${libdir}/monodoc/* \
 "
 
-export MONO_CFG_DIR="${STAGING_ETCDIR_NATIVE}"
+export MONO_CFG_DIR = "${STAGING_ETCDIR_NATIVE}"
 
 # NuGet uses $HOME/.nuget/packages to store packages by default
 # but we should not use anything outside the build root of packages.
-export NUGET_PACKAGES="${UNPACKDIR}/mono-nuget-packages"
-export NUGET_HTTP_CACHE_PATH="${UNPACKDIR}/mono-nuget-http-cache"
+export NUGET_PACKAGES = "${UNPACKDIR}/mono-nuget-packages"
+export NUGET_HTTP_CACHE_PATH = "${UNPACKDIR}/mono-nuget-http-cache"
 
 do_configure:prepend() {
 	mkdir -p ${NUGET_PACKAGES} ${NUGET_HTTP_CACHE_PATH}

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -30,4 +30,4 @@ INSANE_SKIP:msbuild-dev += "buildpaths"
 INSANE_SKIP:python3-clr-loader += "buildpaths"
 INSANE_SKIP:python3-pythonnet += "buildpaths"
 
-LAYERSERIES_COMPAT_mono = "styhead"
+LAYERSERIES_COMPAT_mono = "whinlatter"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -30,4 +30,4 @@ INSANE_SKIP:msbuild-dev += "buildpaths"
 INSANE_SKIP:python3-clr-loader += "buildpaths"
 INSANE_SKIP:python3-pythonnet += "buildpaths"
 
-LAYERSERIES_COMPAT_mono = "whinlatter"
+LAYERSERIES_COMPAT_mono = "wrynose"

--- a/recipes-mono/dbus-sharp-glib/dbus-sharp-glib.inc
+++ b/recipes-mono/dbus-sharp-glib/dbus-sharp-glib.inc
@@ -25,3 +25,5 @@ do_configure:prepend() {
   export DBUS_SHARP_LIBS="/r:${STAGING_LIBDIR}/mono/dbus-sharp-2.0/dbus-sharp.dll"
 }
 
+# suppress: SRC_URI uses unstable GitHub/GitLab archives
+INSANE_SKIP += "src-uri-bad"

--- a/recipes-mono/dbus-sharp/dbus-sharp.inc
+++ b/recipes-mono/dbus-sharp/dbus-sharp.inc
@@ -9,3 +9,6 @@ inherit pkgconfig
 inherit mono
 
 SRC_URI = "https://github.com/mono/dbus-sharp/archive/v${PV}.tar.gz"
+
+# suppress: SRC_URI uses unstable GitHub/GitLab archives
+INSANE_SKIP += "src-uri-bad"

--- a/recipes-mono/dotnet-helloworld/dotnet-helloworld_1.0.bb
+++ b/recipes-mono/dotnet-helloworld/dotnet-helloworld_1.0.bb
@@ -19,13 +19,13 @@ COMPATIBLE_HOST ?= "(x86_64|aarch64|arm).*-linux"
 
 # NuGet MigrationRunner in .NET 6 hardcodes $HOME for migrations dir.
 # Override HOME so it's always writable (CI containers often have read-only HOME).
-export HOME="${WORKDIR}/dotnet-home"
-export DOTNET_CLI_HOME="${WORKDIR}/dotnet-home"
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE="true"
-export DOTNET_CLI_TELEMETRY_OPTOUT="1"
-export DOTNET_NOLOGO="1"
-export NUGET_PACKAGES="${UNPACKDIR}/nuget-packages"
-export NUGET_HTTP_CACHE_PATH="${UNPACKDIR}/nuget-http-cache"
+export HOME = "${WORKDIR}/dotnet-home"
+export DOTNET_CLI_HOME = "${WORKDIR}/dotnet-home"
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE = "true"
+export DOTNET_CLI_TELEMETRY_OPTOUT = "1"
+export DOTNET_NOLOGO = "1"
+export NUGET_PACKAGES = "${UNPACKDIR}/nuget-packages"
+export NUGET_HTTP_CACHE_PATH = "${UNPACKDIR}/nuget-http-cache"
 
 SRC_ARCH:aarch64 = "arm64"
 SRC_ARCH:arm = "arm"

--- a/recipes-mono/dotnet/dotnet.inc
+++ b/recipes-mono/dotnet/dotnet.inc
@@ -120,7 +120,7 @@ mkdir -p "$HOME" 2>/dev/null || true
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_NOLOGO=1
-SELF_DIR = "$(cd "$(dirname "$0")" && pwd)"
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
 exec "${SELF_DIR}/../share/dotnet/dotnet" "$@"
 WRAPPER
     chmod 0755 ${D}${bindir}/dotnet

--- a/recipes-mono/dotnet/dotnet.inc
+++ b/recipes-mono/dotnet/dotnet.inc
@@ -120,7 +120,7 @@ mkdir -p "$HOME" 2>/dev/null || true
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_NOLOGO=1
-SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+SELF_DIR = "$(cd "$(dirname "$0")" && pwd)"
 exec "${SELF_DIR}/../share/dotnet/dotnet" "$@"
 WRAPPER
     chmod 0755 ${D}${bindir}/dotnet

--- a/recipes-mono/fsharp/fsharp.inc
+++ b/recipes-mono/fsharp/fsharp.inc
@@ -17,3 +17,6 @@ FILES:${PN} += "\
   ${libdir}/mono/gac/*/*/*.optdata \
   ${libdir}/mono/gac/*/*/*.sigdata \
 "
+
+# suppress: SRC_URI uses unstable GitHub/GitLab archives
+INSANE_SKIP += "src-uri-bad"

--- a/recipes-mono/fsharp/fsharp_3.1.2.4.bb
+++ b/recipes-mono/fsharp/fsharp_3.1.2.4.bb
@@ -2,4 +2,4 @@ require fsharp.inc
 
 inherit pkgconfig
 
-SRC_URI[sha256sum] = "cf3b5ea00fd13b9d35f5a4ffec6fbd8cecc2c4039d09a79fb0e3f7fa48da9429"
+SRC_URI[sha256sum] = "d846a4e0c8fb0186cc89445a4c1108f4ae683bd14da834a05634e316b233d61b"

--- a/recipes-mono/gtk-sharp/gtk-sharp-native_2.12.45.bb
+++ b/recipes-mono/gtk-sharp/gtk-sharp-native_2.12.45.bb
@@ -2,7 +2,7 @@ require gtk-sharp.inc
 
 inherit pkgconfig native
 
-DEPENDS += " gtk+-native atk-native pango-native cairo-native glib-2.0-native libglade-native "
+DEPENDS += " gtk+-native atk-native pango-native cairo-native glib-2.0-native "
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=7fbc338309ac38fefcd64b04bb903e34"
 

--- a/recipes-mono/gtk-sharp/gtk-sharp3_2.99.3.bb
+++ b/recipes-mono/gtk-sharp/gtk-sharp3_2.99.3.bb
@@ -2,7 +2,7 @@ require gtk-sharp.inc
 
 inherit pkgconfig
 
-DEPENDS += " gtk+3 atk pango cairo glib-2.0 libglade mono"
+DEPENDS += " gtk+3 atk pango cairo glib-2.0 mono"
 RDEPENDS:${PN} += " perl gtk+3"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=8754deb904d22254188cb67189b87f19"

--- a/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
+++ b/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
@@ -8,10 +8,11 @@ RDEPENDS:${PN} += " perl gtk+3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=8754deb904d22254188cb67189b87f19"
 
 SRCREV = "9a72bb67fff7e4845b7bb430a608282668c3e4da"
-SRC_URI = "git://github.com/mono/gtk-sharp.git;protocol=https;branch=master \
+SRC_URI = "git://github.com/mono/gtk-sharp.git;protocol=https;branch=main \
            file://0001-fixup-gmcs-to-mcs.patch"
 
 S = "${UNPACKDIR}/${BP}"
+TARGET_CFLAGS:append = " -Wno-error=implicit-function-declaration"
 
 do_configure:prepend() {
   export PROFILER_CFLAGS="-D_REENTRANT -I${STAGING_DIR_TARGET}/usr/include/glib-2.0 -I${STAGING_DIR_TARGET}/usr/lib/glib-2.0 -I${STAGING_DIR_TARGET}/usr/lib/glib-2.0/include -I${STAGING_DIR_TARGET}/usr/include/mono-2.0"

--- a/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
+++ b/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
@@ -11,7 +11,7 @@ SRCREV = "9a72bb67fff7e4845b7bb430a608282668c3e4da"
 SRC_URI = "git://github.com/mono/gtk-sharp.git;protocol=https;branch=master \
            file://0001-fixup-gmcs-to-mcs.patch"
 
-S = "${UNPACKDIR}/git"
+S = "${UNPACKDIR}/${BP}"
 
 do_configure:prepend() {
   export PROFILER_CFLAGS="-D_REENTRANT -I${STAGING_DIR_TARGET}/usr/include/glib-2.0 -I${STAGING_DIR_TARGET}/usr/lib/glib-2.0 -I${STAGING_DIR_TARGET}/usr/lib/glib-2.0/include -I${STAGING_DIR_TARGET}/usr/include/mono-2.0"

--- a/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
+++ b/recipes-mono/gtk-sharp/gtk-sharp3_2.99.4.bb
@@ -2,7 +2,7 @@ require gtk-sharp.inc
 
 inherit pkgconfig
 
-DEPENDS += " gtk+3 atk pango cairo glib-2.0 libglade mono"
+DEPENDS += " gtk+3 atk pango cairo glib-2.0 mono"
 RDEPENDS:${PN} += " perl gtk+3"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=8754deb904d22254188cb67189b87f19"

--- a/recipes-mono/images/test-image-mono.bb
+++ b/recipes-mono/images/test-image-mono.bb
@@ -10,5 +10,8 @@ IMAGE_INSTALL += "msbuild \
                   dotnet-helloworld \
 "
 
+# Required for qemu testimage (serial/ssh root login) on wrynose+.
+IMAGE_FEATURES += "allow-empty-password empty-root-password allow-root-login"
+
 IMAGE_BASENAME = "${PN}"
 

--- a/recipes-mono/libgdiplus/libgdiplus-common.inc
+++ b/recipes-mono/libgdiplus/libgdiplus-common.inc
@@ -11,7 +11,7 @@ SRC_URI = " \
 	gitsm://github.com/mono/libgdiplus.git;protocol=https;branch=${BRANCH} \
 "
 
-S = "${UNPACKDIR}/git"
+S = "${UNPACKDIR}/${BP}"
 
 inherit autotools pkgconfig
 

--- a/recipes-mono/mono-addins/mono-addins-1.1/0001-configure-mcs.patch
+++ b/recipes-mono/mono-addins/mono-addins-1.1/0001-configure-mcs.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
 diff -ur git.org/configure.ac git/configure.ac
 --- git.org/configure.ac	2015-07-20 11:50:50.151627671 +0100
 +++ git/configure.ac	2015-07-20 11:51:28.275628204 +0100

--- a/recipes-mono/mono-addins/mono-addins-xbuild.inc
+++ b/recipes-mono/mono-addins/mono-addins-xbuild.inc
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4e024d772d8266e3ff9747185842ca82"
 DEPENDS = "mono"
 
 SRCREV = "64a45d96f39d4714ec85adf0fe04b68ec7273ae1"
-SRCBRANCH = "master"
+SRCBRANCH = "main"
 
 SRC_URI = "git://github.com/mono/mono-addins.git;protocol=https;branch=${SRCBRANCH}"
 

--- a/recipes-mono/mono-addins/mono-addins-xbuild.inc
+++ b/recipes-mono/mono-addins/mono-addins-xbuild.inc
@@ -13,7 +13,7 @@ SRCBRANCH = "master"
 
 SRC_URI = "git://github.com/mono/mono-addins.git;protocol=https;branch=${SRCBRANCH}"
 
-S = "${UNPACKDIR}/git"
+S = "${UNPACKDIR}/${BP}"
 
 do_configure() {
 }

--- a/recipes-mono/mono-addins/mono-addins.inc
+++ b/recipes-mono/mono-addins/mono-addins.inc
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4e024d772d8266e3ff9747185842ca82"
 DEPENDS = "gtk-sharp"
 
 SRCREV = "64a45d96f39d4714ec85adf0fe04b68ec7273ae1"
-SRCBRANCH = "master"
+SRCBRANCH = "main"
 
 SRC_URI = "git://github.com/mono/mono-addins.git;protocol=https;branch=${SRCBRANCH} \
 	   file://0001-configure-mcs.patch"

--- a/recipes-mono/mono-addins/mono-addins.inc
+++ b/recipes-mono/mono-addins/mono-addins.inc
@@ -14,7 +14,7 @@ SRCBRANCH = "master"
 SRC_URI = "git://github.com/mono/mono-addins.git;protocol=https;branch=${SRCBRANCH} \
 	   file://0001-configure-mcs.patch"
 
-S = "${UNPACKDIR}/git"
+S = "${UNPACKDIR}/${BP}"
 
 inherit autotools-brokensep pkgconfig
 inherit mono

--- a/recipes-mono/mono-addins/mono-addins_1.1.bb
+++ b/recipes-mono/mono-addins/mono-addins_1.1.bb
@@ -1,5 +1,5 @@
 require mono-addins.inc
 
 SRCREV = "64a45d96f39d4714ec85adf0fe04b68ec7273ae1"
-SRCBRANCH = "master"
+SRCBRANCH = "main"
 

--- a/recipes-mono/mono-basic/mono-basic-4.xx.inc
+++ b/recipes-mono/mono-basic/mono-basic-4.xx.inc
@@ -19,3 +19,6 @@ do_install:append() {
  install -d "${D}${libdir}/mono/4.5"
  ln -sf ${libdir}/mono/4.0/Microsoft.VisualBasic.dll  ${D}${libdir}/mono/4.5/Microsoft.VisualBasic.dll
 }
+
+# suppress: SRC_URI uses unstable GitHub/GitLab archives
+INSANE_SKIP += "src-uri-bad"

--- a/recipes-mono/mono-helloworld/mono-helloworld_git.bb.disabled
+++ b/recipes-mono/mono-helloworld/mono-helloworld_git.bb.disabled
@@ -2,4 +2,4 @@ require mono-helloworld.inc
 
 SRCREV = "${AUTOREV}"
 SRC_URI =  "git://github.com/DynamicDevices/mono-helloworld.git" 
-S = "${UNPACKDIR}/git"
+S = "${UNPACKDIR}/${BP}"

--- a/recipes-mono/mono-upnp/mono-upnp-0.1.2/0001-fixup-build.patch
+++ b/recipes-mono/mono-upnp/mono-upnp-0.1.2/0001-fixup-build.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
 diff -ur git.org/Makefile.am git/Makefile.am
 --- git.org/Makefile.am	2014-05-17 17:18:41.627941046 +0100
 +++ git/Makefile.am	2014-05-17 17:23:49.583941850 +0100

--- a/recipes-mono/mono-upnp/mono-upnp-0.1.2/0002-configure-use-mcs.patch
+++ b/recipes-mono/mono-upnp/mono-upnp-0.1.2/0002-configure-use-mcs.patch
@@ -2,7 +2,7 @@ mono-upnp: use mcs instead of gmcs
 
 as gmcs not present in recent mono releases
 
-Upstream-status: Submitted [https://github.com/mono/mono-upnp/pull/7]
+Upstream-Status: Submitted [https://github.com/mono/mono-upnp/pull/7]
 
 diff -ur git.org/configure.ac git/configure.ac
 --- git.org/configure.ac	2015-07-20 16:03:01.899839044 +0100

--- a/recipes-mono/mono-upnp/mono-upnp.inc
+++ b/recipes-mono/mono-upnp/mono-upnp.inc
@@ -16,7 +16,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}-${PV}:"
 SRC_URI = "git://github.com/mono/mono-upnp.git;protocol=https;branch=${SRCBRANCH} \
 "
 
-S = "${UNPACKDIR}/git"
+S = "${UNPACKDIR}/${BP}"
 
 inherit autotools-brokensep pkgconfig
 

--- a/recipes-mono/mono-xsp/mono-xsp_git.bb
+++ b/recipes-mono/mono-xsp/mono-xsp_git.bb
@@ -1,6 +1,6 @@
 require mono-xsp-3.x.inc
 
-SRCREV= "e272a2c006211b6b03be2ef5bbb9e3f8fefd0768"
+SRCREV = "e272a2c006211b6b03be2ef5bbb9e3f8fefd0768"
 SRC_URI = "git://github.com/mono/xsp.git;branch=main;protocol=https \
 	  "
 

--- a/recipes-mono/mono-xsp/mono-xsp_git.bb
+++ b/recipes-mono/mono-xsp/mono-xsp_git.bb
@@ -4,4 +4,4 @@ SRCREV = "e272a2c006211b6b03be2ef5bbb9e3f8fefd0768"
 SRC_URI = "git://github.com/mono/xsp.git;branch=main;protocol=https \
 	  "
 
-S = "${UNPACKDIR}/git"
+S = "${UNPACKDIR}/${BP}"

--- a/recipes-mono/mono/mono-4.xx.inc
+++ b/recipes-mono/mono/mono-4.xx.inc
@@ -94,4 +94,4 @@ FILES:${PN}-staticdev			+= " ${libdir}/*.a"
 RDEPENDS:${PN}-dev =+ "bash"
 
 # Workaround for observed race in `make install`
-PARALLEL_MAKEINST=""
+PARALLEL_MAKEINST = ""

--- a/recipes-mono/mono/mono-5.xx.inc
+++ b/recipes-mono/mono/mono-5.xx.inc
@@ -106,7 +106,7 @@ RDEPENDS:${PN}-dev =+ "bash"
 RDEPENDS:${PN}-libs =+ "zlib"
 
 # Workaround for observed race in `make install`
-PARALLEL_MAKEINST=""
+PARALLEL_MAKEINST = ""
 
 # Otherwise the full path to bash is written to the first line of doltlibtool script
 # which causes build failures with deeply nested build directories

--- a/recipes-mono/mono/mono-6.12.0.206.inc
+++ b/recipes-mono/mono/mono-6.12.0.206.inc
@@ -1,3 +1,3 @@
-S = "${UNPACKDIR}/git"
+S = "${UNPACKDIR}/${BP}"
 
 DEPENDS += " cmake-native"

--- a/recipes-mono/mono/mono-6.12.0.206/0001-Btls-too-old-cmake-version.patch
+++ b/recipes-mono/mono/mono-6.12.0.206/0001-Btls-too-old-cmake-version.patch
@@ -1,0 +1,30 @@
+From ba1b408ff40e3770785a7774f2bf88758a33a49d Mon Sep 17 00:00:00 2001
+From: Marian Cingel <cingel.marian@gmail.com>
+Date: Mon, 18 May 2026 20:12:28 +0000
+Subject: [PATCH] Btls - too old cmake version
+
+Upstream-Status: Pending
+---
+ mono/btls/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/mono/btls/CMakeLists.txt b/mono/btls/CMakeLists.txt
+index 992f41e4c7f..012b6d12669 100644
+--- a/mono/btls/CMakeLists.txt
++++ b/mono/btls/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 2.8.10)
++cmake_minimum_required (VERSION 4.0)
+ 
+ project (mono-btls)
+ 
+@@ -129,4 +129,4 @@ endif ()
+ 
+ if (CYGWIN)
+ 	target_link_libraries (mono-btls-shared wsock32 ws2_32)
+-endif ()
+\ No newline at end of file
++endif ()
+-- 
+2.53.0
+

--- a/recipes-mono/mono/mono-6.12.0.206/boringssl-cmake-version.diff
+++ b/recipes-mono/mono/mono-6.12.0.206/boringssl-cmake-version.diff
@@ -1,0 +1,10 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
+--- mono-6.12.0.206/external/boringssl/CMakeLists.txt.orig	2026-05-18 22:51:14.239405666 +0000
++++ mono-6.12.0.206/external/boringssl/CMakeLists.txt	2026-05-18 22:51:21.634960290 +0000
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 2.8.10)
++cmake_minimum_required (VERSION 4.0)
+ 
+ # Defer enabling C and CXX languages.
+ project (BoringSSL NONE)

--- a/recipes-mono/mono/mono-6.xx.inc
+++ b/recipes-mono/mono/mono-6.xx.inc
@@ -127,7 +127,7 @@ INSANE_SKIP:${PN}-xbuild		= "file-rdeps"
 INSANE_SKIP:${PN}-configuration-crypto	= "file-rdeps"
 
 # Workaround for observed race in `make install`
-PARALLEL_MAKEINST=""
+PARALLEL_MAKEINST = ""
 
 # Otherwise the full path to bash is written to the first line of doltlibtool script
 # which causes build failures with deeply nested build directories

--- a/recipes-mono/mono/mono-git.inc
+++ b/recipes-mono/mono/mono-git.inc
@@ -83,4 +83,4 @@ FILES:${PN}-profiler			+= " ${datadir}/mono-2.0/mono/profiler/*"
 RDEPENDS:${PN} =+ "bash" 
 
 # Workaround for observed race in `make install`
-PARALLEL_MAKEINST=""
+PARALLEL_MAKEINST = ""

--- a/recipes-mono/mono/mono-git.inc
+++ b/recipes-mono/mono/mono-git.inc
@@ -7,7 +7,7 @@ LICENSE = "GPLv2"
 
 LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=80862f3fd0e11a5fa0318070c54461ce"
 
-SRCBRANCH = "master"
+SRCBRANCH = "main"
 SRCREV = "${AUTOREV}"
 
 SRC_URI = "git://github.com/mono/mono.git;branch=${SRCBRANCH}\

--- a/recipes-mono/mono/mono-git.inc
+++ b/recipes-mono/mono/mono-git.inc
@@ -23,7 +23,7 @@ SRC_URI = "git://github.com/mono/mono.git;branch=${SRCBRANCH}\
 #	   file://0001-reintroduce-gmcs.patch \
 #
 
-S = "${UNPACKDIR}/git"
+S = "${UNPACKDIR}/${BP}"
 
 FILESPATH =. "${FILE_DIRNAME}/mono-4.xx:"
 FILESPATH =. "${FILE_DIRNAME}/mono-${PV}:"

--- a/recipes-mono/mono/mono-native_6.12.0.206.bb
+++ b/recipes-mono/mono/mono-native_6.12.0.206.bb
@@ -12,6 +12,8 @@ SRC_URI = "gitsm://github.com/mono/mono.git;protocol=https;branch=2020-02 \
            file://shm_open-test-crosscompile.diff \
            file://disable-mmap-MAP_32BIT-support.patch \
            file://0001-Allow-passing-external-mapfile-C-build-options.patch \
+           file://0001-Btls-too-old-cmake-version.patch \
+           file://boringssl-cmake-version.diff \
 "
 
 addtask fixup_config after do_patch before do_configure

--- a/recipes-mono/mono/mono_6.12.0.206.bb
+++ b/recipes-mono/mono/mono_6.12.0.206.bb
@@ -12,6 +12,8 @@ SRC_URI = "gitsm://github.com/mono/mono.git;protocol=https;branch=2020-02 \
            file://disable-mmap-MAP_32BIT-support.patch \
            file://0001-Allow-passing-external-mapfile-C-build-options.patch \
            file://0001-Add-libusb-1.0-mapping.patch \
+           file://0001-Btls-too-old-cmake-version.patch \
+           file://boringssl-cmake-version.diff \
 "
 
 

--- a/recipes-mono/msbuild/msbuild_16.10.1.bb
+++ b/recipes-mono/msbuild/msbuild_16.10.1.bb
@@ -35,8 +35,8 @@ do_configure () {
     sed "s|\$1/lib|${libdir}|g" -i ${S}/mono/build/gen_msbuild_wrapper.sh
 }
 
-export DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR="${STAGING_DATADIR_NATIVE}/dotnet"
-export CURL_CA_BUNDLE="${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt"
+export DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR = "${STAGING_DATADIR_NATIVE}/dotnet"
+export CURL_CA_BUNDLE = "${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt"
 
 do_compile[network] = "1"
 

--- a/recipes-mono/msbuild/msbuild_16.10.1.bb
+++ b/recipes-mono/msbuild/msbuild_16.10.1.bb
@@ -21,7 +21,7 @@ SRC_URI = "git://github.com/mono/linux-packaging-msbuild.git;branch=main;protoco
            file://0001-Copy-hostfxr.patch \
            "
 
-S = "${UNPACKDIR}/git"
+S = "${UNPACKDIR}/${BP}"
 
 do_configure () {
     sed "s|%libhostfxr%|${STAGING_DIR_TARGET}${libdir}/libhostfxr.so|g" -i ${S}/eng/cibuild_bootstrapped_msbuild.sh

--- a/recipes-mono/nuget/nuget.inc
+++ b/recipes-mono/nuget/nuget.inc
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://Apache-LICENSE-2.0.txt;md5=3b83ef96387f14655fc854ddc3
 HOMEPAGE = "http://nuget.org/"
 
 # This package ships Mono EXE and a shell script
-PACKAGE_ARCH="all"
+PACKAGE_ARCH = "all"
 
 # Fully updated Fedora 33 and 34 say that dist.nuget.org cert is untrusted
 BB_CHECK_SSL_CERTS = "0"

--- a/recipes-mono/taglib-sharp/taglib-sharp.inc
+++ b/recipes-mono/taglib-sharp/taglib-sharp.inc
@@ -10,7 +10,7 @@ DEPENDS = "mono"
 
 SRC_URI = "git://github.com/mono/taglib-sharp.git;protocol=https;branch=${SRCBRANCH}"
 
-S = "${UNPACKDIR}/git"
+S = "${UNPACKDIR}/${BP}"
 
 inherit autotools-brokensep pkgconfig
 

--- a/recipes-mono/taglib-sharp/taglib-sharp_2.1.0.0.bb
+++ b/recipes-mono/taglib-sharp/taglib-sharp_2.1.0.0.bb
@@ -1,6 +1,6 @@
 require taglib-sharp.inc
 
 SRCREV = "bbdc79138815c81151a5d03fc2dec0cf53044186"
-SRCBRANCH = "master"
+SRCBRANCH = "main"
 
 SRC_URI += "file://0001-configure-use-mcs.patch"

--- a/recipes-python/python3-clr-loader/python3-clr-loader.bb
+++ b/recipes-python/python3-clr-loader/python3-clr-loader.bb
@@ -29,18 +29,18 @@ RDEPENDS:${PN} += " \
 # NuGet uses $HOME/.nuget/packages to store packages by default
 # but we should not use anything outside the build root of packages.
 # Use a separated folder for nuget downloads and cache in UNPACKDIR.
-export NUGET_PACKAGES="${UNPACKDIR}/nuget-packages"
-export NUGET_HTTP_CACHE_PATH="${UNPACKDIR}/nuget-http-cache"
+export NUGET_PACKAGES = "${UNPACKDIR}/nuget-packages"
+export NUGET_HTTP_CACHE_PATH = "${UNPACKDIR}/nuget-http-cache"
 
 # NuGet MigrationRunner.Run() in .NET 6 runs BEFORE the skip-first-time
 # check, and hardcodes $HOME/.local/share/NuGet/Migrations.  In CI
 # containers $HOME is often read-only.  Override HOME to a writable path
 # so NuGet, dotnet CLI, and any other $HOME consumer all get a writable dir.
-export HOME="${WORKDIR}/dotnet-home"
-export DOTNET_CLI_HOME="${WORKDIR}/dotnet-home"
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE="true"
-export DOTNET_CLI_TELEMETRY_OPTOUT="1"
-export DOTNET_NOLOGO="1"
+export HOME = "${WORKDIR}/dotnet-home"
+export DOTNET_CLI_HOME = "${WORKDIR}/dotnet-home"
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE = "true"
+export DOTNET_CLI_TELEMETRY_OPTOUT = "1"
+export DOTNET_NOLOGO = "1"
 
 # Workaround for dotnet restore issue, define custom proxy in a .bbappend
 # and/or in layer.conf or local.conf if dotnet restore was failed.

--- a/recipes-python/python3-clr-loader/python3-clr-loader.bb
+++ b/recipes-python/python3-clr-loader/python3-clr-loader.bb
@@ -47,8 +47,8 @@ export DOTNET_NOLOGO = "1"
 # Override DOTNET_HTTP_PROXY and DOTNET_HTTPS_PROXY in layer.conf or local.conf if needed
 DOTNET_HTTP_PROXY ?= ""
 DOTNET_HTTPS_PROXY ?= ""
-export http_proxy="${DOTNET_HTTP_PROXY}"
-export https_proxy="${DOTNET_HTTPS_PROXY}"
+export http_proxy = "${DOTNET_HTTP_PROXY}"
+export https_proxy = "${DOTNET_HTTPS_PROXY}"
 
 do_configure:prepend() {
     if ! grep -Fq __version__ ${S}/clr_loader/__init__.py

--- a/recipes-python/python3-pythonnet/python3-pythonnet.bb
+++ b/recipes-python/python3-pythonnet/python3-pythonnet.bb
@@ -46,8 +46,8 @@ export NUGET_HTTP_CACHE_PATH = "${UNPACKDIR}/nuget-http-cache"
 # Override DOTNET_HTTP_PROXY and DOTNET_HTTPS_PROXY in layer.conf or local.conf if needed
 DOTNET_HTTP_PROXY ?= ""
 DOTNET_HTTPS_PROXY ?= ""
-export http_proxy="${DOTNET_HTTP_PROXY}"
-export https_proxy="${DOTNET_HTTPS_PROXY}"
+export http_proxy = "${DOTNET_HTTP_PROXY}"
+export https_proxy = "${DOTNET_HTTPS_PROXY}"
 
 do_configure:prepend() {
     if ! grep -Fq __version__ ${S}/pythonnet/__init__.py

--- a/recipes-python/python3-pythonnet/python3-pythonnet.bb
+++ b/recipes-python/python3-pythonnet/python3-pythonnet.bb
@@ -38,8 +38,8 @@ RDEPENDS:${PN} += " \
 # NuGet uses $HOME/.nuget/packages to store packages by default
 # but we should not use anything outside the build root of packages.
 # Use a separated folder for nuget downloads and cache in UNPACKDIR.
-export NUGET_PACKAGES="${UNPACKDIR}/nuget-packages"
-export NUGET_HTTP_CACHE_PATH="${UNPACKDIR}/nuget-http-cache"
+export NUGET_PACKAGES = "${UNPACKDIR}/nuget-packages"
+export NUGET_HTTP_CACHE_PATH = "${UNPACKDIR}/nuget-http-cache"
 
 # Workaround for dotnet restore issue, define custom proxy in a .bbappend
 # and/or in layer.conf or local.conf if dotnet restore was failed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Supersedes CI failures on [#282](https://github.com/DynamicDevices/meta-mono/pull/282).

## Fixes landed so far

1. **HTTPS clones** — Cloudflare breaks `git://` to `git.yoctoproject.org`
2. **Wrynose TEMPLATECONF** — `meta-poky` dropped templates; use oe-core defaults + poky layers
3. **sbom-cve-check** — replaces removed `cve-check`
4. **Disk cleanup + SSTATE_MIRRORS** — runner was filling during clang/llvm/rust
5. **dotnet native wrapper** — `SELF_DIR = "..."` was invalid shell (spaces); broke `dotnet-helloworld` do_compile
6. **export whitespace** — bitbake wrynose warnings for `export FOO="bar"`

Based on Marian Cingel's wrynose recipe work from #282.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27ced430-9c59-4f0c-b41c-8d74b3b9d7c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27ced430-9c59-4f0c-b41c-8d74b3b9d7c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

