### PR TITLE
ci: harden wrynose CVE artifact collection globs

### DIFF
--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -277,13 +277,26 @@ jobs:
         case "$YOCTO_RELEASE" in
           wrynose)
             # Image-level sbom-cve-check runs during bitbake test-image-mono.
+            # OE writes ${IMAGE_NAME}.sbom-cve-check.yocto.json and
+            # ${IMAGE_NAME}.sbom-cve-check.spdx.json into DEPLOY_DIR_IMAGE
+            # (see meta/classes/sbom-cve-check-common.bbclass). Also accept
+            # legacy cve-check names and the docstring alias .sbom-cve-check.json.
             deploy="$GITHUB_WORKSPACE/${WORK_ROOT}/build/tmp/deploy/images/qemu${ARCH}"
-            found=$(ls "$deploy"/*.sbom-cve-check*.json 2>/dev/null | wc -l)
-            if [ "$found" -eq 0 ]; then
-              echo "No sbom-cve-check reports in $deploy" >&2
+            shopt -s nullglob
+            files=(
+              "$deploy"/*.sbom-cve-check.yocto.json
+              "$deploy"/*.sbom-cve-check.spdx.json
+              "$deploy"/*.sbom-cve-check.json
+              "$deploy"/*.cve-check.json
+              "$deploy"/*.cve-check.spdx.json
+            )
+            shopt -u nullglob
+            if [ "${#files[@]}" -eq 0 ]; then
+              echo "No sbom-cve-check / cve-check JSON reports in $deploy" >&2
+              ls -la "$deploy" >&2 || true
               exit 1
             fi
-            cp "$deploy"/*.sbom-cve-check*.json "$cve_dir/"
+            cp -a "${files[@]}" "$cve_dir/"
             ls -la "$cve_dir"
             ;;
           *)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses Cursor Bugbot’s “Wrynose CVE glob wrong” finding on the shared CI workflow.

OE wrynose `sbom-cve-check` deploys `${IMAGE_NAME}.sbom-cve-check.yocto.json` and `${IMAGE_NAME}.sbom-cve-check.spdx.json` (not the older `${IMAGE_NAME}.cve-check.json` names). The previous `*.sbom-cve-check*.json` glob already matched those files; this change makes the step explicit and more resilient:

- Collect the real sbom-cve-check extensions first
- Also accept legacy `.cve-check.json` / `.cve-check.spdx.json` and the docstring alias `.sbom-cve-check.json`
- Use `nullglob` + array copy
- On failure, list the image deploy directory for easier diagnosis

The same fix was pushed to `whinlatter` (updates PR #273). PR #276’s missing-`mkdir` finding was already fixed earlier; a redundant `mkdir -p` was added in the meta-openembedded clone step for step isolation.

## Test plan

- [ ] Confirm master CI CVE step still finds reports after `test-image-mono` (wrynose path)
- [ ] Confirm failure path prints deploy dir listing when no reports exist

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27ced430-9c59-4f0c-b41c-8d74b3b9d7c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27ced430-9c59-4f0c-b41c-8d74b3b9d7c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

