### PR TITLE
recipes: raise btls/boringssl cmake_minimum_required on whinlatter

### DIFF
--- a/recipes-mono/mono/mono-6.12.0.206/0001-Btls-too-old-cmake-version.patch
+++ b/recipes-mono/mono/mono-6.12.0.206/0001-Btls-too-old-cmake-version.patch
@@ -1,0 +1,30 @@
+From ba1b408ff40e3770785a7774f2bf88758a33a49d Mon Sep 17 00:00:00 2001
+From: Marian Cingel <cingel.marian@gmail.com>
+Date: Mon, 18 May 2026 20:12:28 +0000
+Subject: [PATCH] Btls - too old cmake version
+
+Upstream-Status: Pending
+---
+ mono/btls/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/mono/btls/CMakeLists.txt b/mono/btls/CMakeLists.txt
+index 992f41e4c7f..012b6d12669 100644
+--- a/mono/btls/CMakeLists.txt
++++ b/mono/btls/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 2.8.10)
++cmake_minimum_required (VERSION 4.0)
+ 
+ project (mono-btls)
+ 
+@@ -129,4 +129,4 @@ endif ()
+ 
+ if (CYGWIN)
+ 	target_link_libraries (mono-btls-shared wsock32 ws2_32)
+-endif ()
+\ No newline at end of file
++endif ()
+-- 
+2.53.0
+

--- a/recipes-mono/mono/mono-6.12.0.206/boringssl-cmake-version.diff
+++ b/recipes-mono/mono/mono-6.12.0.206/boringssl-cmake-version.diff
@@ -1,0 +1,10 @@
+Upstream-Status: Inappropriate [Yocto specific]
+
+--- mono-6.12.0.206/external/boringssl/CMakeLists.txt.orig	2026-05-18 22:51:14.239405666 +0000
++++ mono-6.12.0.206/external/boringssl/CMakeLists.txt	2026-05-18 22:51:21.634960290 +0000
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 2.8.10)
++cmake_minimum_required (VERSION 4.0)
+ 
+ # Defer enabling C and CXX languages.
+ project (BoringSSL NONE)

--- a/recipes-mono/mono/mono-native_6.12.0.206.bb
+++ b/recipes-mono/mono/mono-native_6.12.0.206.bb
@@ -12,6 +12,8 @@ SRC_URI = "gitsm://github.com/mono/mono.git;protocol=https;branch=2020-02 \
            file://shm_open-test-crosscompile.diff \
            file://disable-mmap-MAP_32BIT-support.patch \
            file://0001-Allow-passing-external-mapfile-C-build-options.patch \
+           file://0001-Btls-too-old-cmake-version.patch \
+           file://boringssl-cmake-version.diff \
 "
 
 addtask fixup_config after do_patch before do_configure

--- a/recipes-mono/mono/mono_6.12.0.206.bb
+++ b/recipes-mono/mono/mono_6.12.0.206.bb
@@ -12,6 +12,8 @@ SRC_URI = "gitsm://github.com/mono/mono.git;protocol=https;branch=2020-02 \
            file://disable-mmap-MAP_32BIT-support.patch \
            file://0001-Allow-passing-external-mapfile-C-build-options.patch \
            file://0001-Add-libusb-1.0-mapping.patch \
+           file://0001-Btls-too-old-cmake-version.patch \
+           file://boringssl-cmake-version.diff \
 "
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Whinlatter CMake rejects `cmake_minimum_required` &lt; 3.5. Backports master's BTLS/BoringSSL cmake version bumps so `mono-native:do_compile` can configure.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27ced430-9c59-4f0c-b41c-8d74b3b9d7c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27ced430-9c59-4f0c-b41c-8d74b3b9d7c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

