### PR TITLE
recipes: fix dotnet-helloworld NuGet HOME on kirkstone

### DIFF
--- a/recipes-mono/dotnet-helloworld/dotnet-helloworld_1.0.bb
+++ b/recipes-mono/dotnet-helloworld/dotnet-helloworld_1.0.bb
@@ -17,6 +17,17 @@ RDEPENDS:${PN}:append = " \
 
 COMPATIBLE_HOST ?= "(x86_64|aarch64|arm).*-linux"
 
+# NuGet MigrationRunner hardcodes $HOME for migrations dir.
+# Override HOME so it's always writable (CI containers often have read-only HOME).
+export HOME = "${WORKDIR}/dotnet-home"
+export DOTNET_CLI_HOME = "${WORKDIR}/dotnet-home"
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE = "true"
+export DOTNET_CLI_TELEMETRY_OPTOUT = "1"
+export DOTNET_NOLOGO = "1"
+export NUGET_PACKAGES = "${WORKDIR}/nuget-packages"
+export NUGET_HTTP_CACHE_PATH = "${WORKDIR}/nuget-http-cache"
+
+
 SRC_ARCH:aarch64 = "arm64"
 SRC_ARCH:arm = "arm"
 SRC_ARCH:x86-64 = "x64"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Backports writable `HOME`/`DOTNET_CLI_HOME` for NuGet MigrationRunner so `dotnet-helloworld:do_compile` works in Actions (same failure mode as clr-loader on read-only `/github/home`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27ced430-9c59-4f0c-b41c-8d74b3b9d7c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27ced430-9c59-4f0c-b41c-8d74b3b9d7c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

