### PR TITLE
ci: add bitbake disk heartbeats on kirkstone

### DIFF
--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -122,7 +122,25 @@ jobs:
     - name: Building Mono Test Image
       run: |
         . ./${BRANCH}/poky/oe-init-build-env ${BRANCH}/build
-        bitbake test-image-mono
+        # Disk heartbeat in the background; wait on bitbake so failures
+        # surface immediately (a foreground sleep loop delayed exit by 5m).
+        bitbake test-image-mono &
+        bbpid=$!
+        (
+          while kill -0 "$bbpid" 2>/dev/null; do
+            sleep 300
+            echo "=== build heartbeat $(date -u +%H:%M:%S) ==="
+            df -h . || true
+          done
+        ) &
+        hb=$!
+        set +e
+        wait "$bbpid"
+        rc=$?
+        set -e
+        kill "$hb" 2>/dev/null || true
+        wait "$hb" 2>/dev/null || true
+        exit "$rc"
     - name: Testing
       run: |
         . ./${BRANCH}/poky/oe-init-build-env ${BRANCH}/build


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds master-style disk heartbeats during `bitbake test-image-mono` so long builds stay visible in Actions logs. Already landed on `kirkstone` as `f8cd22b`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27ced430-9c59-4f0c-b41c-8d74b3b9d7c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27ced430-9c59-4f0c-b41c-8d74b3b9d7c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

